### PR TITLE
Remove the `drop_with_repr_extern` lint.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
 #![forbid(bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
 unknown_crate_types, warnings)]
-#![deny(deprecated, drop_with_repr_extern, improper_ctypes, //missing_docs,
+#![deny(deprecated, improper_ctypes, //missing_docs,
 non_shorthand_field_patterns, overflowing_literals, plugin_as_library,
 private_no_mangle_fns, private_no_mangle_statics, stable_features, unconditional_recursion,
 unknown_lints, unsafe_code, unused, unused_allocation, unused_attributes,


### PR DESCRIPTION
This lint was removed in nightly rust.  Note that while this lint still
exists in the Stable and Beta channels, it only applies if we have types
with `#[repr(C)]` that implement `Drop`.  Since this library has neither
(and will probably never have them), it is safe to remove this lint.