### PR TITLE
Breaking API change: encode and decode bytes, not strings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/Dignifiedquire/rust-multihash"
 
 keywords = ["multihash", "ipfs"]
 
-version = "0.1.0"
+version = "0.2.0"
 
 authors = ["dignifiedquire <dignifiedquire@gmail.com>"]
 
@@ -15,4 +15,3 @@ readme = "README.md"
 
 [dependencies]
 sodiumoxide = "~0.0.9"
-rustc-serialize = "*"

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -1,12 +1,20 @@
-// List of types currently supported in Multihash.
+/// List of types currently supported in the multihash spec.
+///
+/// Not all hash types are supported by this library.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum HashTypes {
-    SHA1, // unsupported
+    /// Encoding unsupported
+    SHA1,
+    /// SHA-256 (32-byte hash size)
     SHA2256,
-    SHA2512, // unsupported
-    SHA3, // unsupported
-    Blake2b, // unsupported
-    Blake2s // unsupported
+    /// SHA-512 (64-byte hash size)
+    SHA2512,
+    /// Encoding unsupported
+    SHA3,
+    /// Encoding unsupported
+    Blake2b,
+    /// Encoding unsupported
+    Blake2s
 }
 
 impl HashTypes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,18 +20,16 @@ missing_debug_implementations)]
 /// Representation of a Multiaddr.
 
 extern crate sodiumoxide;
-extern crate rustc_serialize;
-
-use rustc_serialize::hex::FromHex;
 
 use sodiumoxide::crypto::hash::{sha256, sha512};
 use std::io;
 
-pub use self::hashes::*;
-pub mod hashes;
+mod hashes;
+pub use hashes::*;
 
 
-/// Encode a string into a multihash
+
+/// Encods data into a multihash
 ///
 /// # Examples
 ///
@@ -41,30 +39,26 @@ pub mod hashes;
 /// use multihash::{encode, HashTypes};
 ///
 /// assert_eq!(
-///     encode(HashTypes::SHA2256, "hello world").unwrap(),
-///     "1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+///     encode(HashTypes::SHA2256, "hello world".as_bytes()).unwrap(),
+///     vec![18, 32, 185, 77, 39, 185, 147, 77, 62, 8, 165, 46, 82, 215, 218, 125, 171, 250, 196,
+///     132, 239, 227, 122, 83, 128, 238, 144, 136, 247, 172, 226, 239, 205, 233]
 /// );
 /// ```
 ///
-pub fn encode(wanttype: HashTypes, input: &str) -> io::Result<String> {
-    let digest = match wanttype {
-        HashTypes::SHA2256 => dig_to_vec(&(sha256::hash(input.as_bytes())[..])),
-        HashTypes::SHA2512 => dig_to_vec(&(sha512::hash(input.as_bytes())[..])),
-        _ => None,
+pub fn encode(wanttype: HashTypes, input: &[u8]) -> io::Result<Vec<u8>> {
+    let digest: Vec<u8> = match wanttype {
+        HashTypes::SHA2256 => sha256::hash(input).as_ref().to_owned(),
+        HashTypes::SHA2512 => sha512::hash(input).as_ref().to_owned(),
+        _ => return Err(io::Error::new(io::ErrorKind::Other, "Unsupported hash type"))
     };
 
-    match digest {
-        Some(digest) => {
-            let mut bytes = Vec::new();
+    let mut bytes = Vec::with_capacity(digest.len() + 2);
 
-            bytes.push(wanttype.code());
-            bytes.push(digest.len() as u8);
-            bytes.extend(digest);
+    bytes.push(wanttype.code());
+    bytes.push(digest.len() as u8);
+    bytes.extend(digest);
 
-            Ok(to_hex(bytes))
-        },
-        None => Err(io::Error::new(io::ErrorKind::Other, "Unsupported hash type"))
-    }
+    Ok(bytes)
 }
 
 /// Encode a string into a multihash
@@ -76,38 +70,35 @@ pub fn encode(wanttype: HashTypes, input: &str) -> io::Result<String> {
 /// ```
 /// use multihash::{decode, HashTypes, Multihash};
 ///
+/// // use the data from the `encode` example
+/// let data = vec![18, 32, 185, 77, 39, 185, 147, 77, 62, 8, 165, 46, 82, 215, 218,
+/// 125, 171, 250, 196, 132, 239, 227, 122, 83, 128, 238, 144, 136, 247, 172, 226, 239, 205, 233];
+///
 /// assert_eq!(
-///     decode("1220b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9").unwrap(),
+///     decode(&data).unwrap(),
 ///     Multihash {
 ///         alg: HashTypes::SHA2256,
-///         digest: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+///         digest: &data[2..]
 ///     }
 /// );
 /// ```
 ///
-pub fn decode(input: &str) -> io::Result<Multihash> {
-    if input.len() > 129 {
-        return Err(io::Error::new(io::ErrorKind::Other, "Too long"));
-    }
+pub fn decode(input: &[u8]) -> io::Result<Multihash> {
 
-    if input.len() < 3 {
-        return Err(io::Error::new(io::ErrorKind::Other, "Too short"));
-    }
-
-    let hex_input = input.from_hex();
-
-    if hex_input.is_err() {
-        return Err(io::Error::new(io::ErrorKind::Other, "Failed to parse hex string"));
-    }
-
-    let code = hex_input.unwrap()[0];
+    let code = input[0];
 
     match HashTypes::from_code(code) {
         Some(alg) => {
-            Ok(Multihash {
-                alg: alg,
-                digest: &input[4..],
-            })
+            let hash_len = alg.size() as usize;
+            // length of input should be exactly hash_len + 2
+            if input.len() != hash_len + 2 {
+                Err(io::Error::new(io::ErrorKind::Other, format!("Bad input length.  Expected {}, found {}", hash_len + 2, input.len())))
+            } else {
+                Ok(Multihash {
+                    alg: alg,
+                    digest: &input[2..],
+                })
+            }
         },
         None => {
             Err(io::Error::new(io::ErrorKind::Other, format!("Unkown code {:?}", code)))
@@ -118,19 +109,14 @@ pub fn decode(input: &str) -> io::Result<Multihash> {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Multihash<'a> {
     pub alg: HashTypes,
-    pub digest: &'a str,
+    pub digest: &'a [u8]
 }
 
 /// Convert bytes to a hex representation
-fn to_hex(bytes: Vec<u8>) -> String {
-    bytes.iter().rev().map(|x| {
+pub fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|x| {
         format!("{:02x}", x)
-    }).rev().collect()
+    }).collect()
 }
 
 
-fn dig_to_vec (input: &[u8]) -> Option<Vec<u8>> {
-    let mut bytes = Vec::new();
-    bytes.extend(&input[..]);
-    Some(bytes)
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,17 @@ pub use hashes::*;
 
 
 
-/// Encods data into a multihash
+/// Encodes data into a multihash.  
+///
+/// The returned data is raw bytes.  To make is more human-friendly, you can encode it (hex,
+/// base58, base64, etc).  
+///
+/// # Errors
+///
+/// Will return an error if the specified hash type is not supported.  See the docs for `HashTypes`
+/// to see what is supported.
 ///
 /// # Examples
-///
-/// Simple construction
 ///
 /// ```
 /// use multihash::{encode, HashTypes};
@@ -61,11 +67,13 @@ pub fn encode(wanttype: HashTypes, input: &[u8]) -> io::Result<Vec<u8>> {
     Ok(bytes)
 }
 
-/// Encode a string into a multihash
+/// Decodes bytes into a multihash
+///
+/// # Errors
+///
+/// Returns an error if the bytes are not a valid multihash.
 ///
 /// # Examples
-///
-/// Simple construction
 ///
 /// ```
 /// use multihash::{decode, HashTypes, Multihash};
@@ -106,6 +114,7 @@ pub fn decode(input: &[u8]) -> io::Result<Multihash> {
     }
 }
 
+/// Represents a valid multihash, by associating the hash algorithm with the data
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Multihash<'a> {
     pub alg: HashTypes,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,26 +2,38 @@ extern crate multihash;
 
 use multihash::*;
 
+/// Helper function to convert a hex-encoded byte array back into a bytearray
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    let mut c = 0;
+    let mut v = Vec::new();
+    while c < s.len() {
+        v.push(u8::from_str_radix(&s[c..c+2], 16).unwrap());
+        c += 2;
+    }
+    v
+
+}
+
 #[test]
 fn multihash_encode () {
     assert_eq!(
-        encode(HashTypes::SHA2256, "helloworld").unwrap(),
-        "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af"
+        encode(HashTypes::SHA2256, "helloworld".as_bytes()).unwrap(),
+        hex_to_bytes("1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af")
     );
     assert_eq!(
-        encode(HashTypes::SHA2256, "beep boop").unwrap(),
-        "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c"
+        encode(HashTypes::SHA2256, "beep boop".as_bytes()).unwrap(),
+        hex_to_bytes("122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c")
     );
     assert_eq!(
-        encode(HashTypes::SHA2512, "hello world").unwrap(),
-        "1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f"
+        encode(HashTypes::SHA2512, "hello world".as_bytes()).unwrap(),
+        hex_to_bytes("1340309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f")
     );
 
 }
 
 #[test]
 fn multihash_decode () {
-    let hash = encode(HashTypes::SHA2256, "helloworld").unwrap();
+    let hash: Vec<u8> = encode(HashTypes::SHA2256, "helloworld".as_bytes()).unwrap();
     assert_eq!(
         decode(&hash).unwrap().alg,
         HashTypes::SHA2256


### PR DESCRIPTION
This commit makes an API change to the `encode`, `decode`, and
`MultiHash` functions/types, to operate on bytes, not strings.

In rust, all strings are valid UTF-8, and it's impossible to construct
one that's not.  With the previous API, only UTF-8 data could be hashed,
so the new API operates on bytes instead.

The other API change is for encode to return a Vec<u8> of bytes, instead
of a hex-encoded string.  The hex-encoded string was not incorrect, but
wasn't a nice as it could be, as it forced this particular encoding on
the user.

Other changes:
 * No longer export the `hashes` module, since its contents are already
   exported.
 * Removed the rustc_serialized dependency.
 * Made `to_hex` public, as it might be a useful utility function (and
   removed some unnecessary calls to `.rev()`

Since this is a Breaking Change, the version number has been bumped


You can find me in `#ipfs` as `achin`

[Link](http://ipfs.io/ipfs/Qmb2sWZJvWVQMdiFLyQmST4PeEVRiEszhCu47jr5gB7prA/multihash/) to rendered docs.