### PR TITLE
Support multiple hash function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-sodiumoxide = "~0.0.9"
+rust-crypto = "^0.2"

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -9,6 +9,8 @@ pub enum HashTypes {
     SHA2256,
     /// SHA2-512 (64-byte hash size)
     SHA2512,
+    /// SHA3-512 (64-byte hash size)
+    SHA3512,
     /// SHA3-384 (48-byte hash size)
     SHA3384,
     /// SHA3-256 (32-byte hash size)
@@ -53,6 +55,8 @@ impl HashTypes {
         HashTypes::SHA3384  => 48,
         HashTypes::SHA3256  => 32,
         HashTypes::SHA3224  => 28,
+        HashTypes::SHAKE128 => 16,
+        HashTypes::SHAKE256 => 32,
 	    HashTypes::Blake2b  => 64,
 	    HashTypes::Blake2s  => 32,
         }

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -3,17 +3,25 @@
 /// Not all hash types are supported by this library.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum HashTypes {
-    /// Encoding unsupported
+    /// SHA1 (64-bytee hash size)
     SHA1,
-    /// SHA-256 (32-byte hash size)
+    /// SHA2-256 (32-byte hash size)
     SHA2256,
-    /// SHA-512 (64-byte hash size)
+    /// SHA2-512 (64-byte hash size)
     SHA2512,
-    /// Encoding unsupported
-    SHA3,
-    /// Encoding unsupported
+    /// SHA3-384 (48-byte hash size)
+    SHA3384,
+    /// SHA3-256 (32-byte hash size)
+    SHA3256,
+    /// SHA3-224 (28-byte hash size)
+    SHA3224,
+    /// SHAKE-128
+    SHAKE128,
+    /// SHAKE-256
+    SHAKE256,
+    /// Blake2s
     Blake2b,
-    /// Encoding unsupported
+    /// Blake2b
     Blake2s
 }
 
@@ -21,12 +29,17 @@ impl HashTypes {
     /// Get the corresponding hash code
     pub fn code(&self) -> u8 {
         match *self {
-            HashTypes::SHA1    => 0x11,
-            HashTypes::SHA2256 => 0x12,
-            HashTypes::SHA2512 => 0x13,
-            HashTypes::SHA3    => 0x14,
-            HashTypes::Blake2b => 0x40,
-            HashTypes::Blake2s => 0x41,
+            HashTypes::SHA1     => 0x11,
+            HashTypes::SHA2256  => 0x12,
+            HashTypes::SHA2512  => 0x13,
+            HashTypes::SHA3512  => 0x14,
+            HashTypes::SHA3384  => 0x15,
+            HashTypes::SHA3256  => 0x16,
+            HashTypes::SHA3224  => 0x17,
+            HashTypes::SHAKE128 => 0x18,
+            HashTypes::SHAKE256 => 0x19,
+            HashTypes::Blake2b  => 0x40,
+            HashTypes::Blake2s  => 0x41,
         }
     }
 
@@ -36,7 +49,10 @@ impl HashTypes {
 	    HashTypes::SHA1     => 20,
 	    HashTypes::SHA2256  => 32,
 	    HashTypes::SHA2512  => 64,
-	    HashTypes::SHA3     => 64,
+	    HashTypes::SHA3512  => 64,
+        HashTypes::SHA3384  => 48,
+        HashTypes::SHA3256  => 32,
+        HashTypes::SHA3224  => 28,
 	    HashTypes::Blake2b  => 64,
 	    HashTypes::Blake2s  => 32,
         }
@@ -48,7 +64,12 @@ impl HashTypes {
 	    HashTypes::SHA1     => "SHA1",
 	    HashTypes::SHA2256  => "SHA2-256",
 	    HashTypes::SHA2512  => "SHA2-512",
-	    HashTypes::SHA3     => "SHA3",
+	    HashTypes::SHA3512  => "SHA3-512",
+        HashTypes::SHA3384  => "SHA3-384",
+        HashTypes::SHA3256  => "SHA3-256",
+        HashTypes::SHA3224  => "SHA3-224",
+        HashTypes::SHAKE128 => "SHAKE-128",
+        HashTypes::SHAKE256 => "SHAKE-256",
 	    HashTypes::Blake2b  => "Blake-2b",
 	    HashTypes::Blake2s  => "Blake-2s",
         }
@@ -59,7 +80,12 @@ impl HashTypes {
             0x11 => Some(HashTypes::SHA1),
             0x12 => Some(HashTypes::SHA2256),
             0x13 => Some(HashTypes::SHA2512),
-            0x14 => Some(HashTypes::SHA3),
+            0x14 => Some(HashTypes::SHA3512),
+            0x15 => Some(HashTypes::SHA3384),
+            0x16 => Some(HashTypes::SHA3256),
+            0x17 => Some(HashTypes::SHA3224),
+            0x18 => Some(HashTypes::SHAKE128),
+            0x19 => Some(HashTypes::SHAKE256),
             0x40 => Some(HashTypes::Blake2b),
             0x41 => Some(HashTypes::Blake2s),
             _    => None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,16 @@ missing_debug_implementations)]
 ///! in Rust.
 /// Representation of a Multiaddr.
 
-extern crate sodiumoxide;
+extern crate crypto;
 
-use sodiumoxide::crypto::hash::{sha256, sha512};
+use crypto::digest::Digest;
+
+use crypto::sha1::Sha1;
+use crypto::sha2::{Sha256, Sha512};
+use crypto::sha3::Sha3;
+use crypto::blake2b::Blake2b;
+use crypto::blake2s::Blake2s;
+
 use std::io;
 
 mod hashes;
@@ -29,10 +36,10 @@ pub use hashes::*;
 
 
 
-/// Encodes data into a multihash.  
+/// Encodes data into a multihash.
 ///
 /// The returned data is raw bytes.  To make is more human-friendly, you can encode it (hex,
-/// base58, base64, etc).  
+/// base58, base64, etc).
 ///
 /// # Errors
 ///
@@ -53,10 +60,90 @@ pub use hashes::*;
 ///
 pub fn encode(wanttype: HashTypes, input: &[u8]) -> io::Result<Vec<u8>> {
     let digest: Vec<u8> = match wanttype {
-        HashTypes::SHA2256 => sha256::hash(input).as_ref().to_owned(),
-        HashTypes::SHA2512 => sha512::hash(input).as_ref().to_owned(),
+
+        HashTypes::SHA1 => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha1::new();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHA2256  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha256::new();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHA2512  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha512::new();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHA3512  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha3::sha3_512();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHA3384  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha3::sha3_384();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHA3224  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha3::sha3_224();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHAKE128 => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha3::shake_128();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::SHAKE256 => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Sha3::shake_256();
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::Blake2b  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Blake2b::new(64);
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
+        HashTypes::Blake2s  => {
+            let mut buf : Vec<u8> = Vec::new();
+            let mut hasher = Blake2s::new(32);
+            hasher.input(input);
+            hasher.result(&mut buf);
+            buf
+        },
+
         _ => return Err(io::Error::new(io::ErrorKind::Other, "Unsupported hash type"))
     };
+
 
     let mut bytes = Vec::with_capacity(digest.len() + 2);
 
@@ -127,5 +214,3 @@ pub fn to_hex(bytes: &[u8]) -> String {
         format!("{:02x}", x)
     }).collect()
 }
-
-


### PR DESCRIPTION
Changed from `sodiumoxide` cargo package to `rust-crypto` which is more active development and well-documented.

Now should be support:
- `SHA1`
- `SHA3`
- `SHAKE`
- `Blake2b` & `Blake2s`

Will update the readme and docs in future.
