### PR TITLE
feat: move to ring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,34 @@
 sudo: false
+
 language: rust
+
 addons:
   apt:
     packages:
-    - libcurl4-openssl-dev
-    - libelf-dev
-    - libdw-dev
-    - binutils-dev
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev
+
 rust:
-- beta
-- stable
-install:
-- wget https://github.com/jedisct1/libsodium/releases/download/1.0.6/libsodium-1.0.6.tar.gz
-- tar xvfz libsodium-1.0.6.tar.gz
-- cd libsodium-1.0.6 && ./configure --prefix=$HOME/installed_libsodium && make &&
-  make install && cd ..
-- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
-- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
+  - beta
+  - stable
+
 before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  - |
+    pip install 'travis-cargo<0.2' --user &&
+    export PATH=$HOME/.local/bin:$PATH
+
+install:
+  - pip install --user travis-cargo codecov
+  - export PATH=$PATH:$HOME/.local/bin
+
 script:
-- |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo bench &&
-  travis-cargo --only stable doc
+  - |
+    travis-cargo build &&
+    travis-cargo test &&
+    travis-cargo --only stable doc
+
 after_success:
-- travis-cargo --only stable doc-upload
-- travis-cargo coveralls --no-sudo --verify
-env:
-  global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
-  - secure: GUc+UHxYyfXimut0P0YqwxGiXsGt6GD8SKHQg/+7DeTZpc82KOxzXrBX/fNDK4vXlwPSNxf+V2lvSAbLUljWD91WUCnZMtNyPLLqpfphjBnTbILJNJbf0l6PMcMyhIzbYQO1L9uEn8rnn8d71oqQOZJ57+I2cTArlapBrMix0pl2uhy71Nldx7K0IHWLEbjLF3BycqIKlbGSBjcmF9oTMGq86XEaY+iZ98Itjxmnuw4MAv/tk03YvHcVD5nyhxpgW+qfwkPKKDMwRS7SVgQroOuSYVX0JOBhq+gJ4DOpwwXb+2ynCalmAGJI0n38tdx3oezwEaKEa5rHN5BdF7gpNgq4s3Z/m4f38P+38BmIBzMGPS5cI1Qv3qk/8wHUGSoUurEgS1x84THUwjn3egYJeltQnJDviVPOGffDKgqWh2btTqscT+lHQj3xuo7jQYqwDu+nP0dCygZYXwQ4xfXM9Esv9YCqY8Bny6wdnp18eU9QRlVGb7kTHPTB35gPHhX/HGBYT4tAYNnL7DG+7tM6Vc27qKGVAS4KORY90OT4D5RnWRdZFRO3jhSgB1VE7ZdvD2CxSA4KxjlzYyDoTlFfjkml5fJWyppmvdt2fCvqJ9uWAQ7Nz4G54o5Myn3vdT+PmOJ7BqRaoCIu4Cdb9LVNhHys/cianflzCJ4zdwMY8Fc=
+  - travis-cargo coverage --no-sudo
+  - codecov --file target/kcov/kcov-merged/cobertura.xml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multihash"
 description = "Implementation of the multihash format"
-homepage = "https://github.com/Dignifiedquire/rust-multihash"
+homepage = "https://github.com/multiformats/rust-multihash"
 
 keywords = ["multihash", "ipfs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-sodiumoxide = "~0.0.9"
+ring = "~0.6.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](http://github.com/multiformats/multiformats)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![Build Status](https://img.shields.io/travis/multiformats/rust-multihash/master.svg?style=flat-square)](https://travis-ci.org/multiformats/rust-multihash)
-[![Coverage Status](https://coveralls.io/repos/github/multiformats/rust-multihash/badge.svg?style=flat-square&branch=master)](https://coveralls.io/github/multiformats/rust-multihash)[
+[![codecov](https://codecov.io/gh/multiformats/rust-multihash/branch/master/graph/badge.svg)](https://codecov.io/gh/multiformats/rust-multihash)
 [![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](http://multiformats.github.io/rust-multihash/multihash/struct.Multihash.html)
 [![crates.io](http://meritbadge.herokuapp.com/multihash?style=flat-square)](https://crates.io/crates/multihash)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](http://github.com/multiformats/multiformats)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![Build Status](https://img.shields.io/travis/multiformats/rust-multihash/master.svg?style=flat-square)](https://travis-ci.org/multiformats/rust-multihash)
-[![Coverage Status](https://coveralls.io/repos/multiformats/rust-multihash/badge.svg?style=flat-square&branch=master)](https://coveralls.io/r/multiformats/rust-multihash?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/multiformats/rust-multihash/badge.svg?style=flat-square&branch=master)](https://coveralls.io/github/multiformats/rust-multihash)[
 [![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](http://multiformats.github.io/rust-multihash/multihash/struct.Multihash.html)
 [![crates.io](http://meritbadge.herokuapp.com/multihash?style=flat-square)](https://crates.io/crates/multihash)
 
@@ -46,14 +46,9 @@ let multi = decode(&hash).unwrap();
 
 ## Supported Hash Types
 
-* `SHA2 256`
-* `SHA2 512`
-
-
-## Dependencies
-
-This uses [libsodium](https://github.com/jedisct1/libsodium) and [sodiumoxide](https://github.com/dnaq/sodiumoxide)
-for the hashing so it depends on libsodium being installed.
+* `SHA1`
+* `SHA2-256`
+* `SHA2-512`
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # rust-multihash
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](http://github.com/multiformats/multiformats)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Build Status](https://img.shields.io/travis/multiformats/rust-multihash/master.svg?style=flat-square)](https://travis-ci.org/multiformats/rust-multihash)
-[![codecov](https://codecov.io/gh/multiformats/rust-multihash/branch/master/graph/badge.svg)](https://codecov.io/gh/multiformats/rust-multihash)
-[![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](http://multiformats.github.io/rust-multihash/multihash/struct.Multihash.html)
-[![crates.io](http://meritbadge.herokuapp.com/multihash?style=flat-square)](https://crates.io/crates/multihash)
+[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![Travis CI](https://img.shields.io/travis/multiformats/rust-multihash.svg?style=flat-square&branch=master)](https://travis-ci.org/multiformats/rust-multihash)
+[![codecov.io](https://img.shields.io/codecov/c/github/multiformats/rust-multihash.svg?style=flat-square&branch=master)](https://codecov.io/github/multiformats/rust-multihash?branch=master)
+[![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](http://multiformats.github.io/rust-multihash/multihash/struct.Multiaddr.html)
+[![crates.io](https://img.shields.io/badge/crates.io-v0.1.0-orange.svg?style=flat-square )](https://crates.io/crates/multihash)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
 > [multihash](https://github.com/multiformats/multihash) implementation in Rust.
 
@@ -22,18 +23,16 @@
 
 ## Install
 
-```
-TODO
-```
-
-## Usage
-
 First add this to your `Cargo.toml`
 
 ```toml
 [dependencies]
 multihash = "*"
 ```
+
+Then run `cargo build`.
+
+## Usage
 
 ```rust
 crate extern multihash
@@ -60,9 +59,9 @@ Contributions welcome. Please check out [the issues](https://github.com/multifor
 
 Check out our [contributing document](https://github.com/multiformats/multiformats/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
-Small note: If editing the Readme, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 
 
 ## License
 
-[MIT](LICENSE)
+[MIT](LICENSE) © 2015-2017 Friedel Ziegelmayer

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -10,21 +10,30 @@ pub enum HashTypes {
     /// SHA-512 (64-byte hash size)
     SHA2512,
     /// Encoding unsupported
-    SHA3,
+    SHA3512,
+    /// Encoding unsupported
+    SHA3384,
+    /// Encoding unsupported
+    SHA3256,
+    /// Encoding unsupported
+    SHA3224,
     /// Encoding unsupported
     Blake2b,
     /// Encoding unsupported
-    Blake2s
+    Blake2s,
 }
 
 impl HashTypes {
     /// Get the corresponding hash code
     pub fn code(&self) -> u8 {
         match *self {
-            HashTypes::SHA1    => 0x11,
+            HashTypes::SHA1 => 0x11,
             HashTypes::SHA2256 => 0x12,
             HashTypes::SHA2512 => 0x13,
-            HashTypes::SHA3    => 0x14,
+            HashTypes::SHA3512 => 0x14,
+            HashTypes::SHA3384 => 0x15,
+            HashTypes::SHA3256 => 0x16,
+            HashTypes::SHA3224 => 0x17,
             HashTypes::Blake2b => 0x40,
             HashTypes::Blake2s => 0x41,
         }
@@ -33,24 +42,30 @@ impl HashTypes {
     /// Get the hash length in bytes
     pub fn size(&self) -> u8 {
         match *self {
-	    HashTypes::SHA1     => 20,
-	    HashTypes::SHA2256  => 32,
-	    HashTypes::SHA2512  => 64,
-	    HashTypes::SHA3     => 64,
-	    HashTypes::Blake2b  => 64,
-	    HashTypes::Blake2s  => 32,
+            HashTypes::SHA1 => 20,
+            HashTypes::SHA2256 => 32,
+            HashTypes::SHA2512 => 64,
+            HashTypes::SHA3512 => 64,
+            HashTypes::SHA3384 => 64,
+            HashTypes::SHA3256 => 64,
+            HashTypes::SHA3224 => 64,
+            HashTypes::Blake2b => 64,
+            HashTypes::Blake2s => 32,
         }
     }
 
     /// Get the human readable name
     pub fn name(&self) -> &str {
         match *self {
-	    HashTypes::SHA1     => "SHA1",
-	    HashTypes::SHA2256  => "SHA2-256",
-	    HashTypes::SHA2512  => "SHA2-512",
-	    HashTypes::SHA3     => "SHA3",
-	    HashTypes::Blake2b  => "Blake-2b",
-	    HashTypes::Blake2s  => "Blake-2s",
+            HashTypes::SHA1 => "SHA1",
+            HashTypes::SHA2256 => "SHA2-256",
+            HashTypes::SHA2512 => "SHA2-512",
+            HashTypes::SHA3512 => "SHA3-512",
+            HashTypes::SHA3384 => "SHA3-384",
+            HashTypes::SHA3256 => "SHA3-256",
+            HashTypes::SHA3224 => "SHA3-224",
+            HashTypes::Blake2b => "Blake-2b",
+            HashTypes::Blake2s => "Blake-2s",
         }
     }
 
@@ -59,10 +74,13 @@ impl HashTypes {
             0x11 => Some(HashTypes::SHA1),
             0x12 => Some(HashTypes::SHA2256),
             0x13 => Some(HashTypes::SHA2512),
-            0x14 => Some(HashTypes::SHA3),
+            0x14 => Some(HashTypes::SHA3512),
+            0x15 => Some(HashTypes::SHA3384),
+            0x16 => Some(HashTypes::SHA3256),
+            0x17 => Some(HashTypes::SHA3224),
             0x40 => Some(HashTypes::Blake2b),
             0x41 => Some(HashTypes::Blake2s),
-            _    => None
+            _ => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 /// ! # multihash
 /// !
-/// ! Implementation of [multihash](https://github.com/jbenet/multihash)
+/// ! Implementation of [multihash](https://github.com/multiformats/multihash)
 /// ! in Rust.
 /// Representation of a Multiaddr.
 
@@ -36,11 +36,11 @@ pub use hashes::*;
 ///
 pub fn encode(wanttype: HashTypes, input: &[u8]) -> io::Result<Vec<u8>> {
     let digest: Vec<u8> = match wanttype {
-        // Test is failing, not sure why :/
-        // HashTypes::SHA1 => {
-        //     digest::digest(&digest::SHA256, input)
-        //         .as_ref().to_owned()
-        // }
+        HashTypes::SHA1 => {
+            digest::digest(&digest::SHA1, input)
+                .as_ref()
+                .to_owned()
+        }
         HashTypes::SHA2256 => {
             digest::digest(&digest::SHA256, input)
                 .as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,21 @@
-// For explanation of lint checks, run `rustc -W help`
-// This is adapted from
-// https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
-unknown_crate_types, warnings)]
-#![deny(deprecated, improper_ctypes, //missing_docs,
-non_shorthand_field_patterns, overflowing_literals, plugin_as_library,
-private_no_mangle_fns, private_no_mangle_statics, stable_features, unconditional_recursion,
-unknown_lints, unsafe_code, unused, unused_allocation, unused_attributes,
-unused_comparisons, unused_features, unused_parens, while_true)]
-#![warn(trivial_casts, unused_extern_crates, unused_import_braces,
-unused_qualifications, unused_results, variant_size_differences)]
-#![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
-missing_debug_implementations)]
-
-///! # multihash
-///!
-///! Implementation of [multihash](https://github.com/jbenet/multihash)
-///! in Rust.
+/// ! # multihash
+/// !
+/// ! Implementation of [multihash](https://github.com/jbenet/multihash)
+/// ! in Rust.
 /// Representation of a Multiaddr.
 
-extern crate sodiumoxide;
+extern crate ring;
 
-use sodiumoxide::crypto::hash::{sha256, sha512};
+use ring::digest;
 use std::io;
 
 mod hashes;
 pub use hashes::*;
 
-
-
-/// Encodes data into a multihash.  
+/// Encodes data into a multihash.
 ///
 /// The returned data is raw bytes.  To make is more human-friendly, you can encode it (hex,
-/// base58, base64, etc).  
+/// base58, base64, etc).
 ///
 /// # Errors
 ///
@@ -53,9 +36,22 @@ pub use hashes::*;
 ///
 pub fn encode(wanttype: HashTypes, input: &[u8]) -> io::Result<Vec<u8>> {
     let digest: Vec<u8> = match wanttype {
-        HashTypes::SHA2256 => sha256::hash(input).as_ref().to_owned(),
-        HashTypes::SHA2512 => sha512::hash(input).as_ref().to_owned(),
-        _ => return Err(io::Error::new(io::ErrorKind::Other, "Unsupported hash type"))
+        // Test is failing, not sure why :/
+        // HashTypes::SHA1 => {
+        //     digest::digest(&digest::SHA256, input)
+        //         .as_ref().to_owned()
+        // }
+        HashTypes::SHA2256 => {
+            digest::digest(&digest::SHA256, input)
+                .as_ref()
+                .to_owned()
+        }
+        HashTypes::SHA2512 => {
+            digest::digest(&digest::SHA512, input)
+                .as_ref()
+                .to_owned()
+        }
+        _ => return Err(io::Error::new(io::ErrorKind::Other, "Unsupported hash type")),
     };
 
     let mut bytes = Vec::with_capacity(digest.len() + 2);
@@ -100,17 +96,18 @@ pub fn decode(input: &[u8]) -> io::Result<Multihash> {
             let hash_len = alg.size() as usize;
             // length of input should be exactly hash_len + 2
             if input.len() != hash_len + 2 {
-                Err(io::Error::new(io::ErrorKind::Other, format!("Bad input length.  Expected {}, found {}", hash_len + 2, input.len())))
+                Err(io::Error::new(io::ErrorKind::Other,
+                                   format!("Bad input length.  Expected {}, found {}",
+                                           hash_len + 2,
+                                           input.len())))
             } else {
                 Ok(Multihash {
                     alg: alg,
                     digest: &input[2..],
                 })
             }
-        },
-        None => {
-            Err(io::Error::new(io::ErrorKind::Other, format!("Unkown code {:?}", code)))
         }
+        None => Err(io::Error::new(io::ErrorKind::Other, format!("Unkown code {:?}", code))),
     }
 }
 
@@ -118,14 +115,12 @@ pub fn decode(input: &[u8]) -> io::Result<Multihash> {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Multihash<'a> {
     pub alg: HashTypes,
-    pub digest: &'a [u8]
+    pub digest: &'a [u8],
 }
 
 /// Convert bytes to a hex representation
 pub fn to_hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|x| {
-        format!("{:02x}", x)
-    }).collect()
+    bytes.iter()
+        .map(|x| format!("{:02x}", x))
+        .collect()
 }
-
-

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,6 +17,10 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
 #[test]
 fn multihash_encode () {
     assert_eq!(
+        encode(HashTypes::SHA1, "beep boop".as_bytes()).unwrap(),
+        hex_to_bytes("11147c8357577f51d4f0a8d393aa1aaafb28863d9421")
+    );
+    assert_eq!(
         encode(HashTypes::SHA2256, "helloworld".as_bytes()).unwrap(),
         hex_to_bytes("1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af")
     );
@@ -33,11 +37,23 @@ fn multihash_encode () {
 
 #[test]
 fn multihash_decode () {
+    let hash: Vec<u8> = encode(HashTypes::SHA1, "helloworld".as_bytes()).unwrap();
+    assert_eq!(
+        decode(&hash).unwrap().alg,
+        HashTypes::SHA1
+    );
+
     let hash: Vec<u8> = encode(HashTypes::SHA2256, "helloworld".as_bytes()).unwrap();
     assert_eq!(
         decode(&hash).unwrap().alg,
         HashTypes::SHA2256
-    )
+    );
+
+    let hash: Vec<u8> = encode(HashTypes::SHA2512, "helloworld".as_bytes()).unwrap();
+    assert_eq!(
+        decode(&hash).unwrap().alg,
+        HashTypes::SHA2512
+    );
 }
 
 #[test]


### PR DESCRIPTION
- [x] Replaces `libsodium` with `ring`
- [x] Replaces #6 as rust-crypto is just not enough maintained to make me comfortable depending on it.
- [x] Add sha1 support