### PR TITLE
docs: fix some outdated links and descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ license = "MIT"
 
 readme = "README.md"
 
+documentation = "https://docs.rs/multihash/"
+
 [dependencies]
 tiny-keccak = "~1.0.5"
 ring = "~0.6.2"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
 [![Travis CI](https://img.shields.io/travis/multiformats/rust-multihash.svg?style=flat-square&branch=master)](https://travis-ci.org/multiformats/rust-multihash)
 [![codecov.io](https://img.shields.io/codecov/c/github/multiformats/rust-multihash.svg?style=flat-square&branch=master)](https://codecov.io/github/multiformats/rust-multihash?branch=master)
-[![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](https://multiformats.github.io/rust-multihash/multihash/struct.Multihash.html)
+[![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](https://docs.rs/multihash/)
 [![crates.io](https://img.shields.io/badge/crates.io-v0.4.0-orange.svg?style=flat-square )](https://crates.io/crates/multihash)
 [![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
@@ -48,6 +48,7 @@ let multi = decode(&hash).unwrap();
 * `SHA1`
 * `SHA2-256`
 * `SHA2-512`
+* `SHA3`/`Keccak`
 
 ## Maintainers
 

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -5,7 +5,7 @@ use errors::Error;
 /// Not all hash types are supported by this library.
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub enum Hash {
-    /// Encoding unsupported
+    /// SHA-1 (20-byte hash size)
     SHA1,
     /// SHA-256 (32-byte hash size)
     SHA2256,
@@ -19,13 +19,13 @@ pub enum Hash {
     SHA3256,
     /// SHA3-224 (28-byte hash size)
     SHA3224,
-    // Keccak-224 (28-byte hash size)
+    /// Keccak-224 (28-byte hash size)
     Keccak224,
-    // Keccak-256 (32-byte hash size)
+    /// Keccak-256 (32-byte hash size)
     Keccak256,
-    // Keccak-384 (48-byte hash size)
+    /// Keccak-384 (48-byte hash size)
     Keccak384,
-    // Keccak-512 (64-byte hash size)
+    /// Keccak-512 (64-byte hash size)
     Keccak512,
     /// Encoding unsupported
     Blake2b,


### PR DESCRIPTION
This commit updates the doc link to https://docs.rs/multihash, which will auto-update when new a new version is published to crates.io. Currently, the docs hosted on Github pages are out of date.

I also added a doc link to `Cargo.toml` so a documentation link shows up on crates.io.

Finally, I updated the README section and the doc comments about supported hash functions so they represent the current state of the code.