### PR TITLE
Bump ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ documentation = "https://docs.rs/multihash/"
 
 [dependencies]
 tiny-keccak = "~1.0.5"
-ring = "~0.6.2"
+ring = "~0.7.1"


### PR DESCRIPTION
Current version does not compile on latest stable rustc.
ping @dignifiedquire 