### PR TITLE
Replace "homepage" link with "repository" link.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multihash"
 description = "Implementation of the multihash format"
-homepage = "https://github.com/multiformats/rust-multihash"
+repository = "https://github.com/multiformats/rust-multihash"
 
 keywords = ["multihash", "ipfs"]
 


### PR DESCRIPTION
The crates.io page at https://crates.io/crates/multihash makes it look
like there's no public repository for the project. Improve this by
replacing the "homepage" link with a "repository" link.