### PR TITLE
0.6.0: Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/multiformats/rust-multihash"
 
 keywords = ["multihash", "ipfs"]
 
-version = "0.5.2"
+version = "0.6.0"
 
 authors = ["dignifiedquire <dignifiedquire@gmail.com>"]
 
@@ -17,4 +17,4 @@ documentation = "https://docs.rs/multihash/"
 
 [dependencies]
 tiny-keccak = "1.2"
-ring = "0.7.4"
+ring = "0.9.4"


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another dependend on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.