### PR TITLE
Upgrade ring to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/multiformats/rust-multihash"
 
 keywords = ["multihash", "ipfs"]
 
-version = "0.6.0"
+version = "0.7.0"
 
 authors = ["dignifiedquire <dignifiedquire@gmail.com>"]
 
@@ -17,4 +17,4 @@ documentation = "https://docs.rs/multihash/"
 
 [dependencies]
 tiny-keccak = "1.2"
-ring = "0.9.4"
+ring = "0.12"


### PR DESCRIPTION
For exactly the same reason as #18, this PR upgrades the ring library to version 0.12.
It also bumps multihash to 0.7.0.