### PR TITLE
Make it work on wasm/asmjs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ readme = "README.md"
 documentation = "https://docs.rs/multihash/"
 
 [dependencies]
+sha1 = "0.5"
+sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.2"
-ring = "0.12"


### PR DESCRIPTION
Removes the `ring` dependency and replaces it with `sha1` and `sha2` which successfully compile on wasm and asmjs.