### PR TITLE
Rename `encode` to `sum`, introduce new `encode`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,16 +61,16 @@ macro_rules! match_encoder {
 /// # Examples
 ///
 /// ```
-/// use multihash::{encode, Hash};
+/// use multihash::{sum, Hash};
 ///
 /// assert_eq!(
-///     encode(Hash::SHA2256, b"hello world").unwrap(),
+///     sum(Hash::SHA2256, b"hello world").unwrap(),
 ///     vec![18, 32, 185, 77, 39, 185, 147, 77, 62, 8, 165, 46, 82, 215, 218, 125, 171, 250, 196,
 ///     132, 239, 227, 122, 83, 128, 238, 144, 136, 247, 172, 226, 239, 205, 233]
 /// );
 /// ```
 ///
-pub fn encode(hash: Hash, input: &[u8]) -> Result<Vec<u8>, Error> {
+pub fn sum(hash: Hash, input: &[u8]) -> Result<Vec<u8>, Error> {
     let size = hash.size();
     let mut output = Vec::new();
     output.resize(2 + size as usize, 0);
@@ -91,6 +91,18 @@ pub fn encode(hash: Hash, input: &[u8]) -> Result<Vec<u8>, Error> {
         Keccak512 => tiny::new_keccak512,
     });
 
+    Ok(output)
+}
+
+pub fn encode(hash: Hash, digest: &[u8]) -> Result<Vec<u8>, Error> {
+    let size = hash.size();
+    if digest.len() != size as usize {
+        return Err(Error::BadInputLength);
+    }
+    let mut output = Vec::with_capacity(2 + size as usize);
+    output.push(hash.code());
+    output.push(size);
+    output.extend_from_slice(digest);
     Ok(output)
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,21 +14,21 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
 
 }
 
-macro_rules! assert_encode {
+macro_rules! assert_sum {
     {$( $alg:ident, $data:expr, $expect:expr; )*} => {
         $(
             assert_eq!(
-                encode(Hash::$alg, $data).expect("Must be supported"),
+                sum(Hash::$alg, $data).expect("Must be supported"),
                 hex_to_bytes($expect),
-                "{} encodes correctly", Hash::$alg.name()
+                "{} sums correctly", Hash::$alg.name()
             );
         )*
     }
 }
 
 #[test]
-fn multihash_encode() {
-    assert_encode! {
+fn multihash_sum() {
+    assert_sum! {
         SHA1, b"beep boop", "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
         SHA2256, b"helloworld", "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
         SHA2256, b"beep boop", "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
@@ -79,7 +79,7 @@ macro_rules! assert_roundtrip {
     ($( $alg:ident ),*) => {
         $(
             {
-                let hash: Vec<u8> = encode(Hash::$alg, b"helloworld").unwrap();
+                let hash: Vec<u8> = sum(Hash::$alg, b"helloworld").unwrap();
                 assert_eq!(
                     decode(&hash).unwrap().alg,
                     Hash::$alg
@@ -101,4 +101,13 @@ fn assert_roundtrip() {
 fn hash_types() {
     assert_eq!(Hash::SHA2256.size(), 32);
     assert_eq!(Hash::SHA2256.name(), "SHA2-256");
+}
+
+#[test]
+fn multihash_encode() {
+    // TODO: test other hash functions
+    let sha1_digest = hex_to_bytes("7c8357577f51d4f0a8d393aa1aaafb28863d9421");
+    let encode_result = encode(Hash::SHA1, &sha1_digest[..]);
+    assert_eq!(&encode_result.unwrap(),
+               &hex_to_bytes("11147c8357577f51d4f0a8d393aa1aaafb28863d9421"));
 }


### PR DESCRIPTION
In go-multihash, the `Sum` function takes un-hashed data and a
specification of a hash function and produces multihash bytes
by hashing the input data. The `Encode` function, on the other hand,
produces multihash bytes from an existing hash digest.

This commit adds an equivalent of the `Encode` function from
go-multihash. Since there is already a function named "encode",
this commit also renames it to `sum` to make it similar to the go
version of this library. This is a breaking change.

Closes #25