### PR TITLE
Cargo fmt and Clippy

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use std::{fmt, error};
+use std::{error, fmt};
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -35,10 +35,10 @@ pub enum Hash {
 
 impl Hash {
     /// Get the corresponding hash code
-    pub fn code(&self) -> u8 {
+    pub fn code(self) -> u8 {
         use Hash::*;
 
-        match *self {
+        match self {
             SHA1 => 0x11,
             SHA2256 => 0x12,
             SHA2512 => 0x13,
@@ -56,10 +56,10 @@ impl Hash {
     }
 
     /// Get the hash length in bytes
-    pub fn size(&self) -> u8 {
+    pub fn size(self) -> u8 {
         use Hash::*;
 
-        match *self {
+        match self {
             SHA1 => 20,
             SHA2256 => 32,
             SHA2512 => 64,

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -73,7 +73,6 @@ impl Hash {
             Keccak512 => 64,
             Blake2b => 64,
             Blake2s => 32,
-
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
+use sha2::Digest;
 /// ! # multihash
 /// !
 /// ! Implementation of [multihash](https://github.com/multiformats/multihash)
 /// ! in Rust.
 /// Representation of a Multiaddr.
-
 use std::fmt::Write;
-use sha2::Digest;
 use tiny_keccak::Keccak;
 
 mod hashes;
@@ -16,21 +15,21 @@ pub use errors::*;
 
 // Helper macro for encoding input into output using sha1, sha2 or tiny_keccak
 macro_rules! encode {
-    (sha1, Sha1, $input:expr, $output:expr) => ({
+    (sha1, Sha1, $input:expr, $output:expr) => {{
         let mut hasher = sha1::Sha1::new();
         hasher.update($input);
         $output.copy_from_slice(&hasher.digest().bytes());
-    });
-    (sha2, $algorithm:ident, $input:expr, $output:expr) => ({
+    }};
+    (sha2, $algorithm:ident, $input:expr, $output:expr) => {{
         let mut hasher = sha2::$algorithm::default();
         hasher.input($input);
         $output.copy_from_slice(hasher.result().as_ref());
-    });
-    (tiny, $constructor:ident, $input:expr, $output:expr) => ({
+    }};
+    (tiny, $constructor:ident, $input:expr, $output:expr) => {{
         let mut kec = Keccak::$constructor();
         kec.update($input);
         kec.finalize($output);
-    });
+    }};
 }
 
 // And another one to keep the matching DRY
@@ -47,7 +46,6 @@ macro_rules! match_encoder {
         }
     })
 }
-
 
 /// Encodes data into a multihash.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub fn decode(input: &[u8]) -> Result<Multihash<'_>, Error> {
     }
 
     Ok(Multihash {
-        alg: alg,
+        alg,
         digest: &input[2..],
     })
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,11 +5,10 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
     let mut c = 0;
     let mut v = Vec::new();
     while c < s.len() {
-        v.push(u8::from_str_radix(&s[c..c+2], 16).unwrap());
+        v.push(u8::from_str_radix(&s[c..c + 2], 16).unwrap());
         c += 2;
     }
     v
-
 }
 
 macro_rules! assert_encode {
@@ -90,8 +89,8 @@ macro_rules! assert_roundtrip {
 #[test]
 fn assert_roundtrip() {
     assert_roundtrip!(
-        SHA1, SHA2256, SHA2512, SHA3224, SHA3256, SHA3384, SHA3512,
-        Keccak224, Keccak256, Keccak384, Keccak512
+        SHA1, SHA2256, SHA2512, SHA3224, SHA3256, SHA3384, SHA3512, Keccak224, Keccak256,
+        Keccak384, Keccak512
     );
 }
 


### PR DESCRIPTION
Clippy suggests to pass on small values by value instead of reference.

For example:

```
warning: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
  --> src/hashes.rs:38:17
   |
38 |     pub fn code(&self) -> u8 {
   |                 ^^^^^ help: consider passing by value instead: `self`
   |
   = note: `#[warn(clippy::trivially_copy_pass_by_ref)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref