### PR TITLE
rust-libp2p related changes part 1

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,24 +1,60 @@
 use std::{error, fmt};
 
-#[derive(Debug)]
-pub enum Error {
+/// Error that can happen when encoding some bytes into a multihash.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum EncodeError {
+    /// The requested hash algorithm isn't supported by this library.
     UnsupportedType,
-    BadInputLength,
-    UnknownCode,
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(error::Error::description(self))
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
+impl fmt::Display for EncodeError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::UnsupportedType => "This type is not supported yet",
-            Error::BadInputLength => "Not matching input length",
-            Error::UnknownCode => "Found unknown code",
+            EncodeError::UnsupportedType => write!(f, "This type is not supported yet"),
         }
     }
 }
+
+impl error::Error for EncodeError {}
+
+/// Error that can happen when decoding some bytes.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The input doesn't have a correct length.
+    BadInputLength,
+    /// The code of the hashing algorithm is incorrect.
+    UnknownCode,
+}
+
+impl fmt::Display for DecodeError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DecodeError::BadInputLength => write!(f, "Not matching input length"),
+            DecodeError::UnknownCode => write!(f, "Found unknown code"),
+        }
+    }
+}
+
+impl error::Error for DecodeError {}
+
+/// Error that can happen when decoding some bytes.
+///
+/// Same as `DecodeError`, but allows retreiving the data whose decoding was attempted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodeOwnedError {
+    /// The error.
+    pub error: DecodeError,
+    /// The data whose decoding was attempted.
+    pub data: Vec<u8>,
+}
+
+impl fmt::Display for DecodeOwnedError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+impl error::Error for DecodeOwnedError {}

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -1,5 +1,3 @@
-use crate::errors::Error;
-
 /// List of types currently supported in the multihash spec.
 ///
 /// Not all hash types are supported by this library.
@@ -34,87 +32,61 @@ pub enum Hash {
 }
 
 impl Hash {
-    /// Get the corresponding hash code
+    /// Get the corresponding hash code.
     pub fn code(self) -> u8 {
-        use Hash::*;
-
         match self {
-            SHA1 => 0x11,
-            SHA2256 => 0x12,
-            SHA2512 => 0x13,
-            SHA3224 => 0x17,
-            SHA3256 => 0x16,
-            SHA3384 => 0x15,
-            SHA3512 => 0x14,
-            Keccak224 => 0x1A,
-            Keccak256 => 0x1B,
-            Keccak384 => 0x1C,
-            Keccak512 => 0x1D,
-            Blake2b => 0x40,
-            Blake2s => 0x41,
+            Hash::SHA1 => 0x11,
+            Hash::SHA2256 => 0x12,
+            Hash::SHA2512 => 0x13,
+            Hash::SHA3224 => 0x17,
+            Hash::SHA3256 => 0x16,
+            Hash::SHA3384 => 0x15,
+            Hash::SHA3512 => 0x14,
+            Hash::Keccak224 => 0x1A,
+            Hash::Keccak256 => 0x1B,
+            Hash::Keccak384 => 0x1C,
+            Hash::Keccak512 => 0x1D,
+            Hash::Blake2b => 0x40,
+            Hash::Blake2s => 0x41,
         }
     }
 
-    /// Get the hash length in bytes
+    /// Get the hash length in bytes.
     pub fn size(self) -> u8 {
-        use Hash::*;
-
         match self {
-            SHA1 => 20,
-            SHA2256 => 32,
-            SHA2512 => 64,
-            SHA3224 => 28,
-            SHA3256 => 32,
-            SHA3384 => 48,
-            SHA3512 => 64,
-            Keccak224 => 28,
-            Keccak256 => 32,
-            Keccak384 => 48,
-            Keccak512 => 64,
-            Blake2b => 64,
-            Blake2s => 32,
+            Hash::SHA1 => 20,
+            Hash::SHA2256 => 32,
+            Hash::SHA2512 => 64,
+            Hash::SHA3224 => 28,
+            Hash::SHA3256 => 32,
+            Hash::SHA3384 => 48,
+            Hash::SHA3512 => 64,
+            Hash::Keccak224 => 28,
+            Hash::Keccak256 => 32,
+            Hash::Keccak384 => 48,
+            Hash::Keccak512 => 64,
+            Hash::Blake2b => 64,
+            Hash::Blake2s => 32,
         }
     }
 
-    /// Get the human readable name
-    pub fn name(&self) -> &str {
-        use Hash::*;
-
-        match *self {
-            SHA1 => "SHA1",
-            SHA2256 => "SHA2-256",
-            SHA2512 => "SHA2-512",
-            SHA3512 => "SHA3-512",
-            SHA3384 => "SHA3-384",
-            SHA3256 => "SHA3-256",
-            SHA3224 => "SHA3-224",
-            Keccak224 => "Keccak-224",
-            Keccak256 => "Keccak-256",
-            Keccak384 => "Keccak-384",
-            Keccak512 => "Keccak-512",
-            Blake2b => "Blake-2b",
-            Blake2s => "Blake-2s",
-        }
-    }
-
-    pub fn from_code(code: u8) -> Result<Hash, Error> {
-        use Hash::*;
-
-        Ok(match code {
-            0x11 => SHA1,
-            0x12 => SHA2256,
-            0x13 => SHA2512,
-            0x14 => SHA3512,
-            0x15 => SHA3384,
-            0x16 => SHA3256,
-            0x17 => SHA3224,
-            0x1A => Keccak224,
-            0x1B => Keccak256,
-            0x1C => Keccak384,
-            0x1D => Keccak512,
-            0x40 => Blake2b,
-            0x41 => Blake2s,
-            _ => return Err(Error::UnknownCode),
+    /// Returns the algorithm corresponding to a code, or `None` if no algorith is matching.
+    pub fn from_code(code: u8) -> Option<Hash> {
+        Some(match code {
+            0x11 => Hash::SHA1,
+            0x12 => Hash::SHA2256,
+            0x13 => Hash::SHA2512,
+            0x14 => Hash::SHA3512,
+            0x15 => Hash::SHA3384,
+            0x16 => Hash::SHA3256,
+            0x17 => Hash::SHA3224,
+            0x1A => Hash::Keccak224,
+            0x1B => Hash::Keccak256,
+            0x1C => Hash::Keccak384,
+            0x1D => Hash::Keccak512,
+            0x40 => Hash::Blake2b,
+            0x41 => Hash::Blake2s,
+            _ => return None,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,20 @@
+//! # Multihash
+//!
+//! Implementation of [multihash](https://github.com/multiformats/multihash) in Rust.
+//!
+//! A `Multihash` is a structure that contains a hashing algorithm, plus some hashed data.
+//! A `MultihashRef` is the same as a `Multihash`, except that it doesn't own its data.
+//!
+
+mod errors;
+mod hashes;
+
 use sha2::Digest;
-/// ! # multihash
-/// !
-/// ! Implementation of [multihash](https://github.com/multiformats/multihash)
-/// ! in Rust.
-/// Representation of a Multiaddr.
 use std::fmt::Write;
 use tiny_keccak::Keccak;
 
-mod hashes;
-pub use hashes::*;
-
-mod errors;
-pub use errors::*;
+pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
+pub use hashes::Hash;
 
 // Helper macro for encoding input into output using sha1, sha2 or tiny_keccak
 macro_rules! encode {
@@ -42,19 +45,16 @@ macro_rules! match_encoder {
                 Hash::$hashtype => encode!($lib, $method, $input, $output),
             )*
 
-            _ => return Err(Error::UnsupportedType)
+            _ => return Err(EncodeError::UnsupportedType)
         }
     })
 }
 
 /// Encodes data into a multihash.
 ///
-/// The returned data is raw bytes.  To make is more human-friendly, you can encode it (hex,
-/// base58, base64, etc).
-///
 /// # Errors
 ///
-/// Will return an error if the specified hash type is not supported.  See the docs for `Hash`
+/// Will return an error if the specified hash type is not supported. See the docs for `Hash`
 /// to see what is supported.
 ///
 /// # Examples
@@ -63,13 +63,13 @@ macro_rules! match_encoder {
 /// use multihash::{encode, Hash};
 ///
 /// assert_eq!(
-///     encode(Hash::SHA2256, b"hello world").unwrap(),
+///     encode(Hash::SHA2256, b"hello world").unwrap().into_bytes(),
 ///     vec![18, 32, 185, 77, 39, 185, 147, 77, 62, 8, 165, 46, 82, 215, 218, 125, 171, 250, 196,
 ///     132, 239, 227, 122, 83, 128, 238, 144, 136, 247, 172, 226, 239, 205, 233]
 /// );
 /// ```
 ///
-pub fn encode(hash: Hash, input: &[u8]) -> Result<Vec<u8>, Error> {
+pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
     let size = hash.size();
     let mut output = Vec::new();
     output.resize(2 + size as usize, 0);
@@ -90,59 +90,139 @@ pub fn encode(hash: Hash, input: &[u8]) -> Result<Vec<u8>, Error> {
         Keccak512 => tiny::new_keccak512,
     });
 
-    Ok(output)
+    Ok(Multihash { bytes: output })
 }
 
-/// Decodes bytes into a multihash
-///
-/// # Errors
-///
-/// Returns an error if the bytes are not a valid multihash.
-///
-/// # Examples
-///
-/// ```
-/// use multihash::{decode, Hash, Multihash};
-///
-/// // use the data from the `encode` example
-/// let data = vec![18, 32, 185, 77, 39, 185, 147, 77, 62, 8, 165, 46, 82, 215, 218,
-/// 125, 171, 250, 196, 132, 239, 227, 122, 83, 128, 238, 144, 136, 247, 172, 226, 239, 205, 233];
-///
-/// assert_eq!(
-///     decode(&data).unwrap(),
-///     Multihash {
-///         alg: Hash::SHA2256,
-///         digest: &data[2..]
-///     }
-/// );
-/// ```
-///
-pub fn decode(input: &[u8]) -> Result<Multihash<'_>, Error> {
-    if input.is_empty() {
-        return Err(Error::BadInputLength);
-    }
-
-    let code = input[0];
-
-    let alg = Hash::from_code(code)?;
-    let hash_len = alg.size() as usize;
-
-    // length of input should be exactly hash_len + 2
-    if input.len() != hash_len + 2 {
-        return Err(Error::BadInputLength);
-    }
-
-    Ok(Multihash {
-        alg,
-        digest: &input[2..],
-    })
+/// Represents a valid multihash.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Multihash {
+    bytes: Vec<u8>,
 }
 
-/// Represents a valid multihash, by associating the hash algorithm with the data
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct Multihash<'a> {
-    pub alg: Hash,
-    pub digest: &'a [u8],
+impl Multihash {
+    /// Verifies whether `bytes` contains a valid multihash, and if so returns a `Multihash`.
+    #[inline]
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Multihash, DecodeOwnedError> {
+        if let Err(err) = MultihashRef::from_slice(&bytes) {
+            return Err(DecodeOwnedError {
+                error: err,
+                data: bytes,
+            });
+        }
+
+        Ok(Multihash { bytes })
+    }
+
+    /// Returns the bytes representation of the multihash.
+    #[inline]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Returns the bytes representation of this multihash.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Builds a `MultihashRef` corresponding to this `Multihash`.
+    #[inline]
+    pub fn as_ref(&self) -> MultihashRef {
+        MultihashRef { bytes: &self.bytes }
+    }
+
+    /// Returns which hashing algorithm is used in this multihash.
+    #[inline]
+    pub fn algorithm(&self) -> Hash {
+        self.as_ref().algorithm()
+    }
+
+    /// Returns the hashed data.
+    #[inline]
+    pub fn digest(&self) -> &[u8] {
+        self.as_ref().digest()
+    }
+}
+
+impl<'a> PartialEq<MultihashRef<'a>> for Multihash {
+    #[inline]
+    fn eq(&self, other: &MultihashRef<'a>) -> bool {
+        &*self.bytes == other.bytes
+    }
+}
+
+/// Represents a valid multihash.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct MultihashRef<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> MultihashRef<'a> {
+    /// Verifies whether `bytes` contains a valid multihash, and if so returns a `MultihashRef`.
+    pub fn from_slice(input: &'a [u8]) -> Result<MultihashRef<'a>, DecodeError> {
+        if input.is_empty() {
+            return Err(DecodeError::BadInputLength);
+        }
+
+        // TODO: note that `input[0]` and `input[1]` and technically variable-length integers,
+        // but there's no hashing algorithm implemented in this crate whose code or digest length
+        // is superior to 128
+        let code = input[0];
+
+        // TODO: see comment just above about varints
+        if input[0] >= 128 || input[1] >= 128 {
+            return Err(DecodeError::BadInputLength);
+        }
+
+        let alg = Hash::from_code(code).ok_or(DecodeError::UnknownCode)?;
+        let hash_len = alg.size() as usize;
+
+        // length of input should be exactly hash_len + 2
+        if input.len() != hash_len + 2 {
+            return Err(DecodeError::BadInputLength);
+        }
+
+        if input[1] as usize != hash_len {
+            return Err(DecodeError::BadInputLength);
+        }
+
+        Ok(MultihashRef { bytes: input })
+    }
+
+    /// Returns which hashing algorithm is used in this multihash.
+    #[inline]
+    pub fn algorithm(&self) -> Hash {
+        Hash::from_code(self.bytes[0]).expect("multihash is known to be valid")
+    }
+
+    /// Returns the hashed data.
+    #[inline]
+    pub fn digest(&self) -> &'a [u8] {
+        &self.bytes[2..]
+    }
+
+    /// Builds a `Multihash` that owns the data.
+    ///
+    /// This operation allocates.
+    #[inline]
+    pub fn into_owned(&self) -> Multihash {
+        Multihash {
+            bytes: self.bytes.to_owned(),
+        }
+    }
+
+    /// Returns the bytes representation of this multihash.
+    #[inline]
+    pub fn as_bytes(&self) -> &'a [u8] {
+        &self.bytes
+    }
+}
+
+impl<'a> PartialEq<Multihash> for MultihashRef<'a> {
+    #[inline]
+    fn eq(&self, other: &Multihash) -> bool {
+        self.bytes == &*other.bytes
+    }
 }
 
 /// Convert bytes to a hex representation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl<'a> MultihashRef<'a> {
     ///
     /// This operation allocates.
     #[inline]
-    pub fn into_owned(&self) -> Multihash {
+    pub fn to_owned(&self) -> Multihash {
         Multihash {
             bytes: self.bytes.to_owned(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ mod errors;
 mod hashes;
 
 use sha2::Digest;
-use std::fmt::Write;
 use tiny_keccak::Keccak;
 
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
@@ -223,15 +222,4 @@ impl<'a> PartialEq<Multihash> for MultihashRef<'a> {
     fn eq(&self, other: &Multihash) -> bool {
         self.bytes == &*other.bytes
     }
-}
-
-/// Convert bytes to a hex representation
-pub fn to_hex(bytes: &[u8]) -> String {
-    let mut hex = String::with_capacity(bytes.len() * 2);
-
-    for byte in bytes {
-        write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
-    }
-
-    hex
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-use multihash::*;
+use multihash::{encode, Hash, MultihashRef};
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray
 fn hex_to_bytes(s: &str) -> Vec<u8> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-use multihash::{encode, Hash, MultihashRef};
+use multihash::{encode, Hash, Multihash, MultihashRef};
 
 /// Helper function to convert a hex-encoded byte array back into a bytearray
 fn hex_to_bytes(s: &str) -> Vec<u8> {
@@ -97,4 +97,126 @@ fn assert_roundtrip() {
 #[test]
 fn hash_types() {
     assert_eq!(Hash::SHA2256.size(), 32);
+}
+
+/// Testing the public interface of `Multihash` and `MultihashRef`
+fn test_methods(hash: Hash, prefix: &str, digest: &str) {
+    let expected_bytes = hex_to_bytes(&format!("{}{}", prefix, digest));
+    let multihash = encode(hash, b"hello world").unwrap();
+    assert_eq!(
+        Multihash::from_bytes(expected_bytes.clone()).unwrap(),
+        multihash
+    );
+    assert_eq!(multihash.as_bytes(), &expected_bytes[..]);
+    assert_eq!(multihash.algorithm(), hash);
+    assert_eq!(multihash.digest(), &hex_to_bytes(digest)[..]);
+
+    let multihash_ref = multihash.as_ref();
+    assert_eq!(multihash, multihash_ref);
+    assert_eq!(multihash_ref, multihash);
+    assert_eq!(
+        MultihashRef::from_slice(&expected_bytes[..]).unwrap(),
+        multihash_ref
+    );
+    assert_eq!(multihash_ref.algorithm(), multihash.algorithm());
+    assert_eq!(multihash_ref.digest(), multihash.digest());
+    assert_eq!(multihash_ref.as_bytes(), multihash.as_bytes());
+
+    let multihash_clone = multihash_ref.to_owned();
+    assert_eq!(multihash, multihash_clone);
+    assert_eq!(multihash.into_bytes(), &expected_bytes[..]);
+}
+
+#[test]
+fn multihash_methods() {
+    test_methods(
+        Hash::SHA1,
+        "1114",
+        "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+    );
+    test_methods(
+        Hash::SHA2256,
+        "1220",
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+    );
+    test_methods(
+        Hash::SHA2512,
+        "1340",
+        "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f");
+    test_methods(
+        Hash::SHA3224,
+        "171C",
+        "dfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5",
+    );
+    test_methods(
+        Hash::SHA3256,
+        "1620",
+        "644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938",
+    );
+    test_methods(
+        Hash::SHA3384,
+        "1530",
+        "83bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b");
+    test_methods(
+        Hash::SHA3512,
+        "1440",
+        "840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a");
+    test_methods(
+        Hash::Keccak224,
+        "1A1C",
+        "25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568",
+    );
+    test_methods(
+        Hash::Keccak256,
+        "1B20",
+        "47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad",
+    );
+    test_methods(
+        Hash::Keccak384,
+        "1C30",
+        "65fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f");
+    test_methods(
+        Hash::Keccak512,
+        "1D40",
+        "3ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d");
+}
+
+#[test]
+fn multihash_errors() {
+    assert!(
+        Multihash::from_bytes(Vec::new()).is_err(),
+        "Should error on empty data"
+    );
+    assert!(
+        Multihash::from_bytes(vec![1, 2, 3]).is_err(),
+        "Should error on invalid multihash"
+    );
+    assert!(
+        Multihash::from_bytes(vec![1, 2, 3]).is_err(),
+        "Should error on invalid prefix"
+    );
+    assert!(
+        Multihash::from_bytes(vec![0x12, 0x20, 0xff]).is_err(),
+        "Should error on correct prefix with wrong digest"
+    );
+}
+
+#[test]
+fn multihash_ref_errors() {
+    assert!(
+        MultihashRef::from_slice(&[]).is_err(),
+        "Should error on empty data"
+    );
+    assert!(
+        MultihashRef::from_slice(&[1, 2, 3]).is_err(),
+        "Should error on invalid multihash"
+    );
+    assert!(
+        MultihashRef::from_slice(&[0x12, 0xff, 0x03]).is_err(),
+        "Should error on invalid prefix"
+    );
+    assert!(
+        MultihashRef::from_slice(&[0x12, 0x20, 0xff]).is_err(),
+        "Should error on correct prefix with wrong digest"
+    );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -15,9 +15,9 @@ macro_rules! assert_encode {
     {$( $alg:ident, $data:expr, $expect:expr; )*} => {
         $(
             assert_eq!(
-                encode(Hash::$alg, $data).expect("Must be supported"),
+                encode(Hash::$alg, $data).expect("Must be supported").into_bytes(),
                 hex_to_bytes($expect),
-                "{} encodes correctly", Hash::$alg.name()
+                "{:?} encodes correctly", Hash::$alg
             );
         )*
     }
@@ -46,9 +46,9 @@ macro_rules! assert_decode {
         $(
             let hash = hex_to_bytes($hash);
             assert_eq!(
-                decode(&hash).unwrap().alg,
+                MultihashRef::from_slice(&hash).unwrap().algorithm(),
                 Hash::$alg,
-                "{} decodes correctly", Hash::$alg.name()
+                "{:?} decodes correctly", Hash::$alg
             );
         )*
     }
@@ -76,9 +76,9 @@ macro_rules! assert_roundtrip {
     ($( $alg:ident ),*) => {
         $(
             {
-                let hash: Vec<u8> = encode(Hash::$alg, b"helloworld").unwrap();
+                let hash: Vec<u8> = encode(Hash::$alg, b"helloworld").unwrap().into_bytes();
                 assert_eq!(
-                    decode(&hash).unwrap().alg,
+                    MultihashRef::from_slice(&hash).unwrap().algorithm(),
                     Hash::$alg
                 );
             }
@@ -97,5 +97,4 @@ fn assert_roundtrip() {
 #[test]
 fn hash_types() {
     assert_eq!(Hash::SHA2256.size(), 32);
-    assert_eq!(Hash::SHA2256.name(), "SHA2-256");
 }


### PR DESCRIPTION
I start to backport changes from the multihash version rust-libp2p is using.

I go through all changes and create (hopefully sensible) PRs out of them. I cherry pick commits from the rust-libp2p version and make minimal changes to them (e.g. style or that they compile).

Then I base additional changes that I think make sense on top of those.

This PR is by far the one with the biggest changes, the subsequent PRs should be smaller.