### PR TITLE
rust-libp2p related changes part 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ documentation = "https://docs.rs/multihash/"
 edition = "2018"
 
 [dependencies]
+blake2 = { version = "0.7", default-features = false }
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
-tiny-keccak = "1.2"
+tiny-keccak = "1.4"
+unsigned-varint = "0.2"

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -25,15 +25,19 @@ pub enum Hash {
     Keccak384,
     /// Keccak-512 (64-byte hash size)
     Keccak512,
+    /// BLAKE2b-512 (64-byte hash size)
+    Blake2b512,
     /// Encoding unsupported
-    Blake2b,
+    Blake2b256,
+    /// BLAKE2s-256 (32-byte hash size)
+    Blake2s256,
     /// Encoding unsupported
-    Blake2s,
+    Blake2s128,
 }
 
 impl Hash {
     /// Get the corresponding hash code.
-    pub fn code(self) -> u8 {
+    pub fn code(self) -> u16 {
         match self {
             Hash::SHA1 => 0x11,
             Hash::SHA2256 => 0x12,
@@ -46,8 +50,10 @@ impl Hash {
             Hash::Keccak256 => 0x1B,
             Hash::Keccak384 => 0x1C,
             Hash::Keccak512 => 0x1D,
-            Hash::Blake2b => 0x40,
-            Hash::Blake2s => 0x41,
+            Hash::Blake2b512 => 0xB240,
+            Hash::Blake2b256 => 0xB220,
+            Hash::Blake2s256 => 0xB260,
+            Hash::Blake2s128 => 0xB250,
         }
     }
 
@@ -65,13 +71,15 @@ impl Hash {
             Hash::Keccak256 => 32,
             Hash::Keccak384 => 48,
             Hash::Keccak512 => 64,
-            Hash::Blake2b => 64,
-            Hash::Blake2s => 32,
+            Hash::Blake2b512 => 64,
+            Hash::Blake2b256 => 32,
+            Hash::Blake2s256 => 32,
+            Hash::Blake2s128 => 16,
         }
     }
 
-    /// Returns the algorithm corresponding to a code, or `None` if no algorith is matching.
-    pub fn from_code(code: u8) -> Option<Hash> {
+    /// Returns the algorithm corresponding to a code, or `None` if no algorithm is matching.
+    pub fn from_code(code: u16) -> Option<Hash> {
         Some(match code {
             0x11 => Hash::SHA1,
             0x12 => Hash::SHA2256,
@@ -84,8 +92,10 @@ impl Hash {
             0x1B => Hash::Keccak256,
             0x1C => Hash::Keccak384,
             0x1D => Hash::Keccak512,
-            0x40 => Hash::Blake2b,
-            0x41 => Hash::Blake2s,
+            0xB240 => Hash::Blake2b512,
+            0xB220 => Hash::Blake2b256,
+            0xB260 => Hash::Blake2s256,
+            0xB250 => Hash::Blake2s128,
             _ => return None,
         })
     }

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -25,14 +25,14 @@ pub enum Hash {
     Keccak384,
     /// Keccak-512 (64-byte hash size)
     Keccak512,
+    /// Encoding unsupported
+    Blake2b256,
     /// BLAKE2b-512 (64-byte hash size)
     Blake2b512,
     /// Encoding unsupported
-    Blake2b256,
+    Blake2s128,
     /// BLAKE2s-256 (32-byte hash size)
     Blake2s256,
-    /// Encoding unsupported
-    Blake2s128,
 }
 
 impl Hash {
@@ -50,10 +50,10 @@ impl Hash {
             Hash::Keccak256 => 0x1B,
             Hash::Keccak384 => 0x1C,
             Hash::Keccak512 => 0x1D,
-            Hash::Blake2b512 => 0xB240,
             Hash::Blake2b256 => 0xB220,
-            Hash::Blake2s256 => 0xB260,
+            Hash::Blake2b512 => 0xB240,
             Hash::Blake2s128 => 0xB250,
+            Hash::Blake2s256 => 0xB260,
         }
     }
 
@@ -71,10 +71,10 @@ impl Hash {
             Hash::Keccak256 => 32,
             Hash::Keccak384 => 48,
             Hash::Keccak512 => 64,
-            Hash::Blake2b512 => 64,
             Hash::Blake2b256 => 32,
-            Hash::Blake2s256 => 32,
+            Hash::Blake2b512 => 64,
             Hash::Blake2s128 => 16,
+            Hash::Blake2s256 => 32,
         }
     }
 
@@ -92,10 +92,10 @@ impl Hash {
             0x1B => Hash::Keccak256,
             0x1C => Hash::Keccak384,
             0x1D => Hash::Keccak512,
-            0xB240 => Hash::Blake2b512,
             0xB220 => Hash::Blake2b256,
-            0xB260 => Hash::Blake2s256,
+            0xB240 => Hash::Blake2b512,
             0xB250 => Hash::Blake2s128,
+            0xB260 => Hash::Blake2s256,
             _ => return None,
         })
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -111,10 +111,10 @@ fn hash_types() {
     assert_eq!(Hash::Keccak256.size(), 32);
     assert_eq!(Hash::Keccak384.size(), 48);
     assert_eq!(Hash::Keccak512.size(), 64);
-    assert_eq!(Hash::Blake2b512.size(), 64);
     assert_eq!(Hash::Blake2b256.size(), 32);
-    assert_eq!(Hash::Blake2s256.size(), 32);
+    assert_eq!(Hash::Blake2b512.size(), 64);
     assert_eq!(Hash::Blake2s128.size(), 16);
+    assert_eq!(Hash::Blake2s256.size(), 32);
 }
 
 /// Testing the public interface of `Multihash` and `MultihashRef`

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -38,6 +38,8 @@ fn multihash_encode() {
         Keccak256, b"hello world", "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
         Keccak384, b"hello world", "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
         Keccak512, b"hello world", "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        Blake2b512, b"hello world", "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        Blake2s256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
     }
 }
 
@@ -69,6 +71,8 @@ fn assert_decode() {
         Keccak256, "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
         Keccak384, "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
         Keccak512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        Blake2b512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        Blake2s256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
     }
 }
 
@@ -90,13 +94,27 @@ macro_rules! assert_roundtrip {
 fn assert_roundtrip() {
     assert_roundtrip!(
         SHA1, SHA2256, SHA2512, SHA3224, SHA3256, SHA3384, SHA3512, Keccak224, Keccak256,
-        Keccak384, Keccak512
+        Keccak384, Keccak512, Blake2b512, Blake2s256
     );
 }
 
 #[test]
 fn hash_types() {
+    assert_eq!(Hash::SHA1.size(), 20);
     assert_eq!(Hash::SHA2256.size(), 32);
+    assert_eq!(Hash::SHA2512.size(), 64);
+    assert_eq!(Hash::SHA3224.size(), 28);
+    assert_eq!(Hash::SHA3256.size(), 32);
+    assert_eq!(Hash::SHA3384.size(), 48);
+    assert_eq!(Hash::SHA3512.size(), 64);
+    assert_eq!(Hash::Keccak224.size(), 28);
+    assert_eq!(Hash::Keccak256.size(), 32);
+    assert_eq!(Hash::Keccak384.size(), 48);
+    assert_eq!(Hash::Keccak512.size(), 64);
+    assert_eq!(Hash::Blake2b512.size(), 64);
+    assert_eq!(Hash::Blake2b256.size(), 32);
+    assert_eq!(Hash::Blake2s256.size(), 32);
+    assert_eq!(Hash::Blake2s128.size(), 16);
 }
 
 /// Testing the public interface of `Multihash` and `MultihashRef`

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -197,6 +197,15 @@ fn multihash_methods() {
         Hash::Keccak512,
         "1D40",
         "3ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d");
+    test_methods(
+        Hash::Blake2b512,
+        "c0e40240",
+        "021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0");
+    test_methods(
+        Hash::Blake2s256,
+        "e0e40220",
+        "9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b",
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is a backport of rust-libp2p commit [ad0807b3f3588f2a3f507d6e948932a476ca0753], which adds BLAKE2 support.

[ad0807b3f3588f2a3f507d6e948932a476ca0753]: https://github.com/libp2p/rust-libp2p/commit/ad0807b3f3588f2a3f507d6e948932a476ca0753