### PR TITLE
multihash: Use `Bytes` instead of `Vec<u8>` internally. (#1187)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ edition = "2018"
 [dependencies]
 blake2b_simd = { version = "0.5.9", default-features = false }
 blake2s_simd = { version = "0.5.9", default-features = false }
+bytes = "0.5"
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.4"
-unsigned-varint = "0.2"
+unsigned-varint = "0.3"


### PR DESCRIPTION
multihash: Use `Bytes` instead of `Vec<u8>` internally.

To improve the efficiency of cloning multi-hashes (e.g. as the
representation of `PeerId`s), this PR replaces the `Vec<u8>`
representation with `Bytes`. The API is kept backwards
compatible and does not leak the representation type.

Originally from https://github.com/libp2p/rust-libp2p/commit/8af4a28152d12110dce72128bbe19a34106b1d00.