### PR TITLE
Add support for blake2b256 and blake2s128

### DIFF
--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -27,11 +27,11 @@ pub enum Hash {
     Keccak384,
     /// Keccak-512 (64-byte hash size)
     Keccak512,
-    /// Encoding unsupported
+    /// BLAKE2b-256 (32-byte hash size)
     Blake2b256,
     /// BLAKE2b-512 (64-byte hash size)
     Blake2b512,
-    /// Encoding unsupported
+    /// BLAKE2s-128 (16-byte hash size)
     Blake2s128,
     /// BLAKE2s-256 (32-byte hash size)
     Blake2s256,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -41,6 +41,8 @@ fn multihash_encode() {
         Keccak512, b"hello world", "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
         Blake2b512, b"hello world", "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
         Blake2s256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
+        Blake2b256, b"hello world", "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
+        Blake2s128, b"hello world", "d0e4021037deae0226c30da2ab424a7b8ee14e83";
     }
 }
 
@@ -75,6 +77,8 @@ fn assert_decode() {
         Keccak512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
         Blake2b512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
         Blake2s256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
+        Blake2b256, "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
+        Blake2s128, "d0e4021037deae0226c30da2ab424a7b8ee14e83";
     }
 }
 
@@ -208,6 +212,15 @@ fn multihash_methods() {
         Hash::Blake2s256,
         "e0e40220",
         "9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b",
+    );
+    test_methods(
+        Hash::Blake2b256,
+        "a0e40220",
+        "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610");
+    test_methods(
+        Hash::Blake2s128,
+        "d0e40210",
+        "37deae0226c30da2ab424a7b8ee14e83",
     );
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -216,7 +216,8 @@ fn multihash_methods() {
     test_methods(
         Hash::Blake2b256,
         "a0e40220",
-        "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610");
+        "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610",
+    );
     test_methods(
         Hash::Blake2s128,
         "d0e40210",


### PR DESCRIPTION
- Adds blake2b256 and blake2s128 generation with multihash. 

Would be ideal to be able to pass in the length of hash to these variable hashing functions but I didn't want to rewrite this whole library to support all possible hash lengths for blake hashes. I added support for the two hash lengths defined but not implemented (I needed blake2b256).