### PR TITLE
Use inline storage for small hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.4"
 unsigned-varint = "0.3"
+
+[dev-dependencies]
+quickcheck = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ edition = "2018"
 [dependencies]
 blake2b_simd = { version = "0.5.9", default-features = false }
 blake2s_simd = { version = "0.5.9", default-features = false }
-bytes = "0.5"
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub struct Multihash {
 
 impl Debug for Multihash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Multihash")
+        f.debug_tuple("Multihash").field(&self.as_bytes()).finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,6 @@ pub use hashes::Hash;
 use std::fmt;
 use storage::Storage;
 
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
 // Helper macro for encoding input into output using sha1, sha2, tiny_keccak, or blake2
 macro_rules! encode {
     (sha1, Sha1, $input:expr, $output:expr) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,15 +108,8 @@ pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
         let code = encode::u16(hash.code(), &mut buf);
         let mut len_buf = encode::u32_buffer();
         let size = encode::u32(input.len() as u32, &mut len_buf);
-
-        let total_len = code.len() + size.len() + input.len();
-
-        let mut output = Vec::with_capacity(total_len);
-        output.extend_from_slice(code);
-        output.extend_from_slice(size);
-        output.extend_from_slice(input);
         Ok(Multihash {
-            storage: Storage::from_slice(&output),
+            storage: Storage::from_slices(&[&code, &size, &input]),
         })
     } else {
         let (offset, mut output) = encode_hash(hash);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,10 @@ pub use hashes::Hash;
 use std::fmt;
 use storage::Storage;
 
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
+
 // Helper macro for encoding input into output using sha1, sha2, tiny_keccak, or blake2
 macro_rules! encode {
     (sha1, Sha1, $input:expr, $output:expr) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
         output.extend_from_slice(size);
         output.extend_from_slice(input);
         Ok(Multihash {
-            storage: Storage::copy_from_slice(&output),
+            storage: Storage::from_slice(&output),
         })
     } else {
         let (offset, mut output) = encode_hash(hash);
@@ -139,7 +139,7 @@ pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
         });
 
         Ok(Multihash {
-            storage: Storage::copy_from_slice(&output),
+            storage: Storage::from_slice(&output),
         })
     }
 }
@@ -196,7 +196,7 @@ impl Multihash {
             });
         }
         Ok(Multihash {
-            storage: Storage::copy_from_slice(&bytes),
+            storage: Storage::from_slice(&bytes),
         })
     }
 
@@ -342,7 +342,7 @@ impl<'a> MultihashRef<'a> {
     /// This operation allocates.
     pub fn to_owned(&self) -> Multihash {
         Multihash {
-            storage: Storage::copy_from_slice(self.bytes),
+            storage: Storage::from_slice(self.bytes),
         }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -62,7 +62,7 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use super::{Storage, MAX_INLINE};
-    use quickcheck;
+    use quickcheck::quickcheck;
 
     #[test]
     fn struct_size() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -21,7 +21,7 @@ impl Storage {
     }
 
     /// creates storage from a vec. Note that this will not preserve the size.
-    pub fn copy_from_slice(slice: &[u8]) -> Self {
+    pub fn from_slice(slice: &[u8]) -> Self {
         if slice.len() <= MAX_INLINE {
             let mut data: [u8; MAX_INLINE] = [0; MAX_INLINE];
             data[..slice.len()].copy_from_slice(slice);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+const MAX_INLINE: usize = 39;
+
+#[derive(Clone)]
+pub enum Storage {
+    /// hash is stored inline. if it is smaller than 39 bytes it should be padded with 0u8
+    Inline([u8; MAX_INLINE]),
+    /// hash is stored on the heap. this must be only used if the hash is actually larger than
+    /// 39 bytes to ensure an unique representation.
+    Heap(Arc<[u8]>),
+}
+
+impl Storage {
+    /// The raw bytes. Note that this can be longer than the data this storage has been created from.
+    pub fn bytes(&self) -> &[u8] {
+        match self {
+            Storage::Inline(bytes) => bytes,
+            Storage::Heap(data) => &data,
+        }
+    }
+
+    /// creates storage from a vec. Note that this will not preserve the size.
+    pub fn copy_from_slice(slice: &[u8]) -> Self {
+        if slice.len() <= MAX_INLINE {
+            let mut data: [u8; MAX_INLINE] = [0; MAX_INLINE];
+            &data[..slice.len()].copy_from_slice(slice);
+            Storage::Inline(data)
+        } else {
+            Storage::Heap(slice.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Storage;
+
+    #[test]
+    fn test_size() {
+        assert_eq!(std::mem::size_of::<Storage>(), 40);
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -80,10 +80,17 @@ mod tests {
         }
     }
 
+    fn check_invariants(storage: Storage) -> bool {
+        match storage {
+            Storage::Inline(len, _) => len as usize <= MAX_INLINE,
+            Storage::Heap(arc) => arc.len() > MAX_INLINE,
+        }
+    }
+
     quickcheck! {
         fn roundtrip_check(data: Vec<u8>) -> bool {
             let storage = Storage::from_slice(&data);
-            storage.bytes() == data.as_slice()
+            storage.bytes() == data.as_slice() && check_invariants(storage)
         }
 
         fn from_slices_roundtrip_check(data: Vec<Vec<u8>>) -> bool {
@@ -94,7 +101,7 @@ mod tests {
                 expected.extend_from_slice(&v);
             }
             let storage = Storage::from_slices(&slices);
-            storage.bytes() == expected.as_slice()
+            storage.bytes() == expected.as_slice() && check_invariants(storage)
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -62,6 +62,7 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use super::{Storage, MAX_INLINE};
+    use quickcheck;
 
     #[test]
     fn struct_size() {
@@ -76,6 +77,24 @@ mod tests {
             let data = (0..i).collect::<Vec<u8>>();
             let storage = Storage::from_slice(&data);
             assert_eq!(data, storage.bytes());
+        }
+    }
+
+    quickcheck! {
+        fn roundtrip_check(data: Vec<u8>) -> bool {
+            let storage = Storage::from_slice(&data);
+            storage.bytes() == data.as_slice()
+        }
+
+        fn from_slices_roundtrip_check(data: Vec<Vec<u8>>) -> bool {
+            let mut slices = Vec::new();
+            let mut expected = Vec::new();
+            for v in data.iter() {
+                slices.push(v.as_slice());
+                expected.extend_from_slice(&v);
+            }
+            let storage = Storage::from_slices(&slices);
+            storage.bytes() == expected.as_slice()
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -24,7 +24,7 @@ impl Storage {
     pub fn copy_from_slice(slice: &[u8]) -> Self {
         if slice.len() <= MAX_INLINE {
             let mut data: [u8; MAX_INLINE] = [0; MAX_INLINE];
-            &data[..slice.len()].copy_from_slice(slice);
+            data[..slice.len()].copy_from_slice(slice);
             Storage::Inline(data)
         } else {
             Storage::Heap(slice.into())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,11 @@
 use std::sync::Arc;
 
+/// MAX_INLINE is the maximum size of a multihash that can be stored inline
+///
+/// We want the currently most common multihashes using 256bit hashes to be stored inline. These
+/// hashes are 34 bytes long. An overall size of 38 seems like a good compromise. It allows storing
+/// any 256bit hash with some room to spare and gives an overall size for Storage of 40 bytes, which
+/// is a multiple of 8. We need 2 extra bytes, one for the size and one for the enum discriminator.
 const MAX_INLINE: usize = 38;
 
 #[derive(Clone)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,31 +1,32 @@
 use std::sync::Arc;
 
-const MAX_INLINE: usize = 39;
+const MAX_INLINE: usize = 38;
 
 #[derive(Clone)]
 pub enum Storage {
-    /// hash is stored inline. if it is smaller than 39 bytes it should be padded with 0u8
-    Inline([u8; MAX_INLINE]),
+    /// hash is stored inline if it is smaller than MAX_INLINE
+    Inline(u8, [u8; MAX_INLINE]),
     /// hash is stored on the heap. this must be only used if the hash is actually larger than
-    /// 39 bytes to ensure an unique representation.
+    /// MAX_INLINE bytes to ensure an unique representation.
     Heap(Arc<[u8]>),
 }
 
 impl Storage {
-    /// The raw bytes. Note that this can be longer than the data this storage has been created from.
+    /// The raw bytes.
     pub fn bytes(&self) -> &[u8] {
         match self {
-            Storage::Inline(bytes) => bytes,
+            Storage::Inline(len, bytes) => &bytes[..(*len as usize)],
             Storage::Heap(data) => &data,
         }
     }
 
-    /// creates storage from a vec. Note that this will not preserve the size.
+    /// creates storage from a vec. For a size up to MAX_INLINE, this will not allocate.
     pub fn from_slice(slice: &[u8]) -> Self {
-        if slice.len() <= MAX_INLINE {
+        let len = slice.len();
+        if len <= MAX_INLINE {
             let mut data: [u8; MAX_INLINE] = [0; MAX_INLINE];
-            data[..slice.len()].copy_from_slice(slice);
-            Storage::Inline(data)
+            data[..len].copy_from_slice(slice);
+            Storage::Inline(len as u8, data)
         } else {
             Storage::Heap(slice.into())
         }
@@ -34,10 +35,21 @@ impl Storage {
 
 #[cfg(test)]
 mod tests {
-    use super::Storage;
+    use super::{Storage, MAX_INLINE};
 
     #[test]
-    fn test_size() {
+    fn struct_size() {
+        // this should be true for both 32 and 64 bit archs
         assert_eq!(std::mem::size_of::<Storage>(), 40);
+    }
+
+    #[test]
+    fn roundtrip() {
+        // check that .bytes() returns whatever the storage was created with
+        for i in 0..((MAX_INLINE + 10) as u8) {
+            let data = (0..i).collect::<Vec<u8>>();
+            let storage = Storage::from_slice(&data);
+            assert_eq!(data, storage.bytes());
+        }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -276,3 +276,8 @@ fn multihash_ref_errors() {
         "Should error on wrong hash length"
     );
 }
+
+#[test]
+fn multihash_size() {
+    assert_eq!(std::mem::size_of::<Multihash>(), 40);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -276,8 +276,3 @@ fn multihash_ref_errors() {
         "Should error on wrong hash length"
     );
 }
-
-#[test]
-fn multihash_size() {
-    assert_eq!(std::mem::size_of::<Multihash>(), 40);
-}


### PR DESCRIPTION
This also gets rid of the Bytes dependency and replaces it with an `Arc<[u8]>`.

Implementation for https://github.com/multiformats/rust-multihash/issues/46

Note that the size of this new multihash is 40, where as the size of the old Bytes based multihash is 32, plus the stuff on the heap. I think this is a pretty good tradeoff!