### PR TITLE
Add ordering for Multihash and MultihashRef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,13 @@ impl TryFrom<Vec<u8>> for Multihash {
 
 impl PartialOrd for Multihash {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.as_ref().cmp(&other.as_ref()))
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Multihash {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.as_ref().cmp(&other.as_ref())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl PartialOrd for Multihash {
 }
 
 /// Represents a valid multihash.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MultihashRef<'a> {
     bytes: &'a [u8],
 }
@@ -328,12 +328,6 @@ impl<'a> MultihashRef<'a> {
 impl<'a> PartialEq<Multihash> for MultihashRef<'a> {
     fn eq(&self, other: &Multihash) -> bool {
         self.as_bytes() == &*other.as_bytes()
-    }
-}
-
-impl<'a> PartialOrd for MultihashRef<'a> {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.as_bytes().cmp(other.as_bytes()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use unsigned_varint::{decode, encode};
 
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::Hash;
-use std::fmt;
+use std::{cmp, fmt};
 use storage::Storage;
 
 // Helper macro for encoding input into output using sha1, sha2, tiny_keccak, or blake2
@@ -246,8 +246,14 @@ impl TryFrom<Vec<u8>> for Multihash {
     }
 }
 
+impl PartialOrd for Multihash {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.as_ref().cmp(&other.as_ref()))
+    }
+}
+
 /// Represents a valid multihash.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, Hash)]
 pub struct MultihashRef<'a> {
     bytes: &'a [u8],
 }
@@ -322,6 +328,12 @@ impl<'a> MultihashRef<'a> {
 impl<'a> PartialEq<Multihash> for MultihashRef<'a> {
     fn eq(&self, other: &Multihash) -> bool {
         self.as_bytes() == &*other.as_bytes()
+    }
+}
+
+impl<'a> PartialOrd for MultihashRef<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.as_bytes().cmp(other.as_bytes()))
     }
 }
 


### PR DESCRIPTION
This is just lexicographical byte ordering, which should be very fast
in case of multihashes since they usually differ within the first 8 byte
word.

Ordering is useful to have if you e.g. want to output a set of multihashes
in a deterministic way for debugging/testing purposes. Also, many possible storage engines work using lexicographical byte ordering. And it allows you to use ordering based collections like BTreeSet with multihashes.

This is based on https://github.com/multiformats/rust-multihash/pull/47 , so should be reviewed once
that is merged.