### PR TITLE
Hash and Multihash arbitrary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,16 @@ sha-1 = { version = "0.8", default-features = false }
 sha2 = { version = "0.8", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 unsigned-varint = "0.3"
+quickcheck = { version = "0.9.2", optional = true }
+rand = { version = "0.7.3", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-rand = "0.7"
 quickcheck = "0.9.2"
+rand = "0.7.3"
+
+[features]
+test = ["quickcheck", "rand"]
 
 [[bench]]
 name = "multihash"

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,17 +1,16 @@
-use crate::hashes::{Hash, Hash::*};
-use crate::{encode, Multihash};
+use crate::{Code, Code::*, Multihash};
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-const HASHES: [Hash; 16] = [
-    Identity, SHA1, SHA2256, SHA2512, SHA3512, SHA3384, SHA3256, SHA3224, Keccak224, Keccak256,
-    Keccak384, Keccak512, Blake2b256, Blake2b512, Blake2s128, Blake2s256,
+const HASHES: [Code; 16] = [
+    Identity, Sha1, Sha2_256, Sha2_512, Sha3_512, Sha3_384, Sha3_256, Sha3_224, Keccak224,
+    Keccak256, Keccak384, Keccak512, Blake2b256, Blake2b512, Blake2s128, Blake2s256,
 ];
 
 /// Generates a random hash algorithm.
 ///
 /// The more exotic ones will be generated just as frequently as the common ones.
-impl Arbitrary for Hash {
+impl Arbitrary for Code {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         *HASHES.choose(g).unwrap()
     }
@@ -22,11 +21,11 @@ impl Arbitrary for Hash {
 /// This is done by encoding a random piece of data.
 impl Arbitrary for Multihash {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let hash: Hash = Arbitrary::arbitrary(g);
+        let code: Code = Arbitrary::arbitrary(g);
         let data: Vec<u8> = Arbitrary::arbitrary(g);
         // encoding an actual random piece of data might be better than just choosing
         // random numbers of the appropriate size, since some hash algos might produce
         // a limited set of values
-        encode(hash, &data).unwrap()
+        code.hasher().unwrap().digest(&data)
     }
 }

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,0 +1,32 @@
+use crate::hashes::{Hash, Hash::*};
+use crate::{encode, Multihash};
+use quickcheck::{Arbitrary, Gen};
+use rand::seq::SliceRandom;
+
+const HASHES: [Hash; 16] = [
+    Identity, SHA1, SHA2256, SHA2512, SHA3512, SHA3384, SHA3256, SHA3224, Keccak224, Keccak256,
+    Keccak384, Keccak512, Blake2b256, Blake2b512, Blake2s128, Blake2s256,
+];
+
+/// Generates a random hash algorithm.
+///
+/// The more exotic ones will be generated just as frequently as the common ones.
+impl Arbitrary for Hash {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        *HASHES.choose(g).unwrap()
+    }
+}
+
+/// Generates a random valid multihash.
+///
+/// This is done by encoding a random piece of data.
+impl Arbitrary for Multihash {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let hash: Hash = Arbitrary::arbitrary(g);
+        let data: Vec<u8> = Arbitrary::arbitrary(g);
+        // encoding an actual random piece of data might be better than just choosing
+        // random numbers of the appropriate size, since some hash algos might produce
+        // a limited set of values
+        encode(hash, &data).unwrap()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ mod errors;
 mod hashes;
 mod storage;
 
+#[cfg(any(test, feature = "test"))]
+mod arb;
+
 pub use digests::{wrap, Multihash, MultihashDigest, MultihashRef};
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::*;


### PR DESCRIPTION
Implements #48 

This is a request for discussion about if this way of providing arbitraries both for internal use and for use from other crates is a good way to go.

If somebody has a simpler way to achieve this I am eager to hear about it...

I verified that the dependencies are not in the output unless you build with the feature flag enabled. See https://github.com/rklaehn/rust-feature-experiment

This is based on https://github.com/multiformats/rust-multihash/pull/47 , so should be reviewed once that is merged.