### PR TITLE
WIP streaming support, macro refactor

### DIFF
--- a/benches/multihash.rs
+++ b/benches/multihash.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 
 use multihash::{
     Blake2b256, Blake2b512, Blake2s128, Blake2s256, Identity, Keccak224, Keccak256, Keccak384,
-    Keccak512, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
+    Keccak512, MultihashDigest, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
 };
 
 macro_rules! group_digest {
@@ -13,6 +13,28 @@ macro_rules! group_digest {
             group.bench_function($id, |b| {
                 b.iter(|| {
                     let _ = black_box($hash::digest($input));
+                })
+            });
+        )*
+        group.finish();
+    }};
+}
+
+macro_rules! group_stream {
+    ($criterion:ident, $( $id:expr => $hash:ident, $input:expr)* ) => {{
+        let mut group = $criterion.benchmark_group("stream");
+        $(
+            group.bench_function($id, |b| {
+                b.iter(|| {
+                    let _ = black_box({
+                        let mut hasher = <$hash>::default();
+                        for i in 0..3 {
+                            let start = i * 256;
+                            let input: &[u8] = $input.as_ref();
+                            &mut hasher.input(&input[start..(start + 256)]);
+                        }
+                        hasher.result()
+                    });
                 })
             });
         )*
@@ -43,5 +65,29 @@ fn bench_digest(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benches, bench_digest);
+/// Chunks the data into 256-byte slices.
+fn bench_stream(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let data: Vec<u8> = (0..1024).map(|_| rng.gen()).collect();
+    group_stream!(c,
+        "identity" => Identity, &data
+        "sha1" => Sha1, &data
+        "sha2_256" => Sha2_256, &data
+        "sha2_512" => Sha2_512, &data
+        "sha3_224" => Sha3_224, &data
+        "sha3_256" => Sha3_256, &data
+        "sha3_384" => Sha3_384, &data
+        "sha3_512" => Sha3_512, &data
+        "keccak_224" => Keccak224, &data
+        "keccak_256" => Keccak256, &data
+        "keccak_384" => Keccak384, &data
+        "keccak_512" => Keccak512, &data
+        "blake2b_256" => Blake2b256, &data
+        "blake2b_512" => Blake2b512, &data
+        "blake2s_128" => Blake2s128, &data
+        "blake2s_256" => Blake2s256, &data
+    );
+}
+
+criterion_group!(benches, bench_digest, bench_stream);
 criterion_main!(benches);

--- a/benches/multihash.rs
+++ b/benches/multihash.rs
@@ -30,8 +30,7 @@ macro_rules! group_stream {
                         let mut hasher = <$hash>::default();
                         for i in 0..3 {
                             let start = i * 256;
-                            let input: &[u8] = $input.as_ref();
-                            &mut hasher.input(&input[start..(start + 256)]);
+                            &mut hasher.input(&$input[start..(start + 256)]);
                         }
                         hasher.result()
                     });

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -213,7 +213,7 @@ impl<'a> MultihashRef<'a> {
     pub fn algorithm(&self) -> Code {
         let (code, _bytes) =
             varint_decode::u64(&self.bytes).expect("multihash is known to be valid algorithm");
-        Code::from_u64(code)
+        Code::from(code)
     }
 
     /// Returns the hash digest.
@@ -313,7 +313,7 @@ pub trait MultihashDigest {
 /// ```
 pub fn wrap(code: Code, data: &[u8]) -> Multihash {
     let mut code_buf = varint_encode::u64_buffer();
-    let code = varint_encode::u64(code.to_u64(), &mut code_buf);
+    let code = varint_encode::u64(code.into(), &mut code_buf);
 
     let mut size_buf = varint_encode::u64_buffer();
     let size = varint_encode::u64(data.len() as u64, &mut size_buf);

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -282,6 +282,18 @@ pub trait MultihashDigest {
     ///
     /// Panics if the digest length is bigger than 2^32. This only happens for identity hasing.
     fn digest(&self, data: &[u8]) -> Multihash;
+
+    /// Digest input data.
+    ///
+    /// This method can be called repeatedly for use with streaming messages.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the digest length is bigger than 2^32. This only happens for identity hashing.
+    fn input(&mut self, data: &[u8]);
+
+    /// Retrieve the computed `Multihash`, consuming the hasher.
+    fn result(self) -> Multihash;
 }
 
 /// Wraps a hash digest in Multihash with the given Mutlihash code.

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -294,6 +294,14 @@ pub trait MultihashDigest {
 
     /// Retrieve the computed `Multihash`, consuming the hasher.
     fn result(self) -> Multihash;
+
+    /// Retrieve result and reset hasher instance.
+    ///
+    /// This method sometimes can be more efficient compared to hasher re-creation.
+    fn result_reset(&mut self) -> Multihash;
+
+    /// Reset hasher instance to its initial state.
+    fn reset(&mut self);
 }
 
 /// Wraps a hash digest in Multihash with the given Mutlihash code.

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -238,49 +238,49 @@ impl Identity {
 derive_digest! {
     /// The SHA-1 hasher.
     @sha ::sha1::Sha1 as Sha1;
-        @code_doc "The code of the SHA-1 hasher, 0x11",
+        @code_doc "The code of the SHA-1 hasher, 0x11.",
     /// The SHA2-256 hasher.
     @sha ::sha2::Sha256 as Sha2_256;
-        @code_doc "The code of the SHA2-256 hasher, 0x12",
+        @code_doc "The code of the SHA2-256 hasher, 0x12.",
     /// The SHA2-512 hasher.
     @sha ::sha2::Sha512 as Sha2_512;
-        @code_doc "The code of the SHA2-512 hasher, 0x13",
+        @code_doc "The code of the SHA2-512 hasher, 0x13.",
     /// The SHA3-224 hasher.
     @sha ::sha3::Sha3_224 as Sha3_224;
-        @code_doc "The code of the SHA3-224 hasher, 0x17",
+        @code_doc "The code of the SHA3-224 hasher, 0x17.",
     /// The SHA3-256 hasher.
     @sha ::sha3::Sha3_256 as Sha3_256;
-        @code_doc "The code of the SHA3-256 hasher, 0x16",
+        @code_doc "The code of the SHA3-256 hasher, 0x16.",
     /// The SHA3-384 hasher.
     @sha ::sha3::Sha3_384 as Sha3_384;
-        @code_doc "The code of the SHA3-384 hasher, 0x15",
+        @code_doc "The code of the SHA3-384 hasher, 0x15.",
     /// The SHA3-512 hasher.
     @sha ::sha3::Sha3_512 as Sha3_512;
-        @code_doc "The code of the SHA3-512 hasher, 0x14",
+        @code_doc "The code of the SHA3-512 hasher, 0x14.",
     /// The Keccak-224 hasher.
     @sha ::sha3::Keccak224 as Keccak224;
-        @code_doc "The code of the Keccak-224 hasher, 0x1a",
+        @code_doc "The code of the Keccak-224 hasher, 0x1a.",
     /// The Keccak-256 hasher.
     @sha ::sha3::Keccak256 as Keccak256;
-        @code_doc "The code of the Keccak-256 hasher, 0x1b",
+        @code_doc "The code of the Keccak-256 hasher, 0x1b.",
     /// The Keccak-384 hasher.
     @sha ::sha3::Keccak384 as Keccak384;
-        @code_doc "The code of the Keccak-384 hasher, 0x1c",
+        @code_doc "The code of the Keccak-384 hasher, 0x1c.",
     /// The Keccak-512 hasher.
     @sha ::sha3::Keccak512 as Keccak512;
-        @code_doc "The code of the Keccak-512 hasher, 0x1d",
+        @code_doc "The code of the Keccak-512 hasher, 0x1d.",
 }
 derive_digest! {
     /// The Blake2b-256 hasher.
     @blake Blake2b | Blake2bParams as Blake2b256 32;
-        @code_doc "The code of the Blake2-256 hasher, 0xb220",
+        @code_doc "The code of the Blake2-256 hasher, 0xb220.",
     /// The Blake2b-512 hasher.
     @blake Blake2b | Blake2bParams as Blake2b512 64;
-        @code_doc "The code of the Blake2-512 hasher, 0xb240",
+        @code_doc "The code of the Blake2-512 hasher, 0xb240.",
     /// The Blake2s-128 hasher.
     @blake Blake2s | Blake2sParams as Blake2s128 16;
-        @code_doc "The code of the Blake2-128 hasher, 0xb250",
+        @code_doc "The code of the Blake2-128 hasher, 0xb250.",
     /// The Blake2s-256 hasher.
     @blake Blake2s | Blake2sParams as Blake2s256 32;
-        @code_doc "The code of the Blake2-256 hasher, 0xb260",
+        @code_doc "The code of the Blake2-256 hasher, 0xb260.",
 }

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -253,7 +253,7 @@ impl MultihashDigest for Identity {
     }
     #[inline]
     fn reset(&mut self) {
-        self.0 = Vec::new();
+        self.0.clear()
     }
 }
 impl Identity {

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -23,24 +23,6 @@ macro_rules! impl_code {
         }
 
         impl Code {
-            /// Return the code as integer value.
-            pub fn to_u64(&self) -> u64 {
-                match *self {
-                    $(Self::$name => $code,)*
-                    Self::Custom(code) => code,
-                }
-            }
-
-            /// Return the `Code` based on the integer value. If the code is
-            /// unknown/not implemented yet then it returns a `Code::Custom`.
-            /// implements with that value.
-            pub fn from_u64(code: u64) -> Self {
-                match code {
-                    $($code => Self::$name,)*
-                    _ => Self::Custom(code),
-                }
-            }
-
             /// Return the hasher that is used to create a hash with this code.
             ///
             /// If a custom code is used, `None` is returned.
@@ -48,6 +30,28 @@ macro_rules! impl_code {
                 match *self {
                     $(Self::$name => Some(Box::new($name::default())),)*
                     Self::Custom(_) => None,
+                }
+            }
+        }
+
+        impl From<Code> for u64 {
+            /// Return the code as integer value.
+            fn from(code: Code) -> Self {
+                match code {
+                    $(Code::$name => $code,)*
+                    Code::Custom(code) => code,
+                }
+            }
+        }
+
+        impl From<u64> for Code {
+            /// Return the `Code` based on the integer value. If the code is
+            /// unknown/not implemented yet then it returns a `Code::Custom`.
+            /// implements with that value.
+            fn from(code: u64) -> Self {
+                match code {
+                    $($code => Self::$name,)*
+                    _ => Self::Custom(code),
                 }
             }
         }

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -130,7 +130,7 @@ macro_rules! derive_digest {
                 }
                 fn result(self) -> Multihash {
                     let digest = self.0.finalize();
-                    wrap(Self::CODE, &digest.as_bytes())
+                    wrap(Self::CODE, digest.as_bytes())
                 }
             }
 

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -57,13 +57,17 @@ macro_rules! impl_code {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! derive_digest {
-    ($(#[$doc:meta] @sha $type:ty as $name:ident,)*) => {
+    ($(
+        #[$doc:meta]
+        @sha $type:ty as $name:ident;
+            @code_doc $code_doc:literal,
+    )*) => {
         $(
             #[$doc]
             #[derive(Clone, Debug, Default)]
             pub struct $name($type);
             impl $name {
-                /// The code of the hasher.
+                #[doc = $code_doc]
                 pub const CODE: Code = Code::$name;
 
                 /// Hash some input and return the Multihash digest.
@@ -90,13 +94,17 @@ macro_rules! derive_digest {
             derive_digest!(@io_write $name);
         )*
     };
-    ($(#[$doc:meta] @blake $type:ty | $params:ty as $name:ident $len:expr,)*) => {
+    ($(
+        #[$doc:meta]
+        @blake $type:ty | $params:ty as $name:ident $len:expr;
+            @code_doc $code_doc:literal,
+    )*) => {
         $(
             #[$doc]
             #[derive(Clone, Debug)]
             pub struct $name($type);
             impl $name {
-                /// The code of the hasher.
+                #[doc = $code_doc]
                 pub const CODE: Code = Code::$name;
 
                 /// Hash some input and return the Multihash digest.
@@ -211,35 +219,50 @@ impl Identity {
 
 derive_digest! {
     /// The SHA-1 hasher.
-    @sha ::sha1::Sha1 as Sha1,
+    @sha ::sha1::Sha1 as Sha1;
+        @code_doc "The code of the SHA-1 hasher, 0x11",
     /// The SHA2-256 hasher.
-    @sha ::sha2::Sha256 as Sha2_256,
+    @sha ::sha2::Sha256 as Sha2_256;
+        @code_doc "The code of the SHA2-256 hasher, 0x12",
     /// The SHA2-512 hasher.
-    @sha ::sha2::Sha512 as Sha2_512,
+    @sha ::sha2::Sha512 as Sha2_512;
+        @code_doc "The code of the SHA2-512 hasher, 0x13",
     /// The SHA3-224 hasher.
-    @sha ::sha3::Sha3_224 as Sha3_224,
+    @sha ::sha3::Sha3_224 as Sha3_224;
+        @code_doc "The code of the SHA3-224 hasher, 0x17",
     /// The SHA3-256 hasher.
-    @sha ::sha3::Sha3_256 as Sha3_256,
+    @sha ::sha3::Sha3_256 as Sha3_256;
+        @code_doc "The code of the SHA3-256 hasher, 0x16",
     /// The SHA3-384 hasher.
-    @sha ::sha3::Sha3_384 as Sha3_384,
+    @sha ::sha3::Sha3_384 as Sha3_384;
+        @code_doc "The code of the SHA3-384 hasher, 0x15",
     /// The SHA3-512 hasher.
-    @sha ::sha3::Sha3_512 as Sha3_512,
+    @sha ::sha3::Sha3_512 as Sha3_512;
+        @code_doc "The code of the SHA3-512 hasher, 0x14",
     /// The Keccak-224 hasher.
-    @sha ::sha3::Keccak224 as Keccak224,
+    @sha ::sha3::Keccak224 as Keccak224;
+        @code_doc "The code of the Keccak-224 hasher, 0x1a",
     /// The Keccak-256 hasher.
-    @sha ::sha3::Keccak256 as Keccak256,
+    @sha ::sha3::Keccak256 as Keccak256;
+        @code_doc "The code of the Keccak-256 hasher, 0x1b",
     /// The Keccak-384 hasher.
-    @sha ::sha3::Keccak384 as Keccak384,
+    @sha ::sha3::Keccak384 as Keccak384;
+        @code_doc "The code of the Keccak-384 hasher, 0x1c",
     /// The Keccak-512 hasher.
-    @sha ::sha3::Keccak512 as Keccak512,
+    @sha ::sha3::Keccak512 as Keccak512;
+        @code_doc "The code of the Keccak-512 hasher, 0x1d",
 }
 derive_digest! {
     /// The Blake2b-256 hasher.
-    @blake Blake2b | Blake2bParams as Blake2b256 32,
+    @blake Blake2b | Blake2bParams as Blake2b256 32;
+        @code_doc "The code of the Blake2-256 hasher, 0xb220",
     /// The Blake2b-512 hasher.
-    @blake Blake2b | Blake2bParams as Blake2b512 64,
+    @blake Blake2b | Blake2bParams as Blake2b512 64;
+        @code_doc "The code of the Blake2-512 hasher, 0xb240",
     /// The Blake2s-128 hasher.
-    @blake Blake2s | Blake2sParams as Blake2s128 16,
+    @blake Blake2s | Blake2sParams as Blake2s128 16;
+        @code_doc "The code of the Blake2-128 hasher, 0xb250",
     /// The Blake2s-256 hasher.
-    @blake Blake2s | Blake2sParams as Blake2s256 32,
+    @blake Blake2s | Blake2sParams as Blake2s256 32;
+        @code_doc "The code of the Blake2-256 hasher, 0xb260",
 }

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -168,7 +168,7 @@ macro_rules! derive_digest {
                 }
                 #[inline]
                 fn reset(&mut self) {
-                    self.0 = <$params>::new().hash_length($len).to_state();
+                    self.0 = Self::default().0;
                 }
             }
             impl ::std::io::Write for $name {
@@ -226,26 +226,32 @@ impl_code! {
 #[derive(Clone, Debug, Default)]
 pub struct Identity(Vec<u8>);
 impl MultihashDigest for Identity {
+    #[inline]
     fn code(&self) -> Code {
         Self::CODE
     }
+    #[inline]
     fn digest(&self, data: &[u8]) -> Multihash {
         Self::digest(data)
     }
+    #[inline]
     fn input(&mut self, data: &[u8]) {
         if ((self.0.len() as u64) + (data.len() as u64)) >= u64::from(std::u32::MAX) {
             panic!("Input data for identity hash is too large, it needs to be less than 2^32.")
         }
         self.0.extend_from_slice(data)
     }
+    #[inline]
     fn result(self) -> Multihash {
         wrap(Self::CODE, &self.0)
     }
+    #[inline]
     fn result_reset(&mut self) -> Multihash {
         let hash = wrap(Self::CODE, &self.0);
         self.reset();
         hash
     }
+    #[inline]
     fn reset(&mut self) {
         self.0 = Vec::new();
     }

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -227,7 +227,7 @@ impl Identity {
         if (data.len() as u64) >= u64::from(std::u32::MAX) {
             panic!("Input data for identity hash is too large, it needs to be less than 2^32.")
         }
-        wrap(Self::CODE, &data)
+        wrap(Self::CODE, data)
     }
 }
 

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -33,6 +33,11 @@ fn custom_multihash_digest() {
             let data = b"alwaysthesame";
             wrap(Self.code(), data)
         }
+
+        fn input(&mut self, _data: &[u8]) {}
+        fn result(self) -> Multihash {
+            Self::digest(&self, &[])
+        }
     }
 
     let my_hash = SameHash.digest(b"abc");

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -35,6 +35,7 @@ fn custom_multihash_digest() {
         }
 
         fn input(&mut self, _data: &[u8]) {}
+
         fn result(self) -> Multihash {
             Self::digest(&self, &[])
         }

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -39,6 +39,12 @@ fn custom_multihash_digest() {
         fn result(self) -> Multihash {
             Self::digest(&self, &[])
         }
+
+        fn result_reset(&mut self) -> Multihash {
+            Self::digest(&self, &[])
+        }
+
+        fn reset(&mut self) {}
     }
 
     let my_hash = SameHash.digest(b"abc");

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -2,14 +2,14 @@ use multihash::{wrap, Code, Multihash, MultihashDigest, Sha3_512};
 
 #[test]
 fn to_u64() {
-    assert_eq!(Code::Keccak256.to_u64(), 0x1b);
-    assert_eq!(Code::Custom(0x1234).to_u64(), 0x1234);
+    assert_eq!(<u64>::from(Code::Keccak256), 0x1b);
+    assert_eq!(<u64>::from(Code::Custom(0x1234)), 0x1234);
 }
 
 #[test]
 fn from_u64() {
-    assert_eq!(Code::from_u64(0xb220), Code::Blake2b256);
-    assert_eq!(Code::from_u64(0x0011_2233), Code::Custom(0x0011_2233));
+    assert_eq!(Code::from(0xb220), Code::Blake2b256);
+    assert_eq!(Code::from(0x0011_2233), Code::Custom(0x0011_2233));
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -32,6 +32,7 @@ macro_rules! assert_encode {
     }
 }
 
+#[allow(clippy::cognitive_complexity)]
 #[test]
 fn multihash_encode() {
     assert_encode! {
@@ -116,6 +117,7 @@ macro_rules! assert_roundtrip {
     }
 }
 
+#[allow(clippy::cognitive_complexity)]
 #[test]
 fn assert_roundtrip() {
     assert_roundtrip!(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -245,7 +245,7 @@ fn custom_multihash() {
         &[0xb4, 0x24, 0x05, 0x61, 0x62, 0x63, 0x64, 0x65]
     );
     assert_eq!(multihash.algorithm(), code);
-    assert_eq!(multihash.algorithm().to_u64(), 0x1234);
+    assert_eq!(<u64>::from(multihash.algorithm()), 0x1234);
     assert_eq!(multihash.digest(), b"abcde");
 }
 
@@ -267,7 +267,7 @@ fn multihash_errors() {
         Multihash::from_bytes(vec![0x12, 0x20, 0xff]).is_err(),
         "Should error on correct prefix with wrong digest"
     );
-    let identity_code = Identity::CODE.to_u64() as u8;
+    let identity_code = <u64>::from(Identity::CODE) as u8;
     let identity_length = 3;
     assert!(
         Multihash::from_bytes(vec![identity_code, identity_length, 1, 2, 3, 4]).is_err(),
@@ -293,7 +293,7 @@ fn multihash_ref_errors() {
         MultihashRef::from_slice(&[0x12, 0x20, 0xff]).is_err(),
         "Should error on correct prefix with wrong digest"
     );
-    let identity_code = Identity::CODE.to_u64() as u8;
+    let identity_code = <u64>::from(Identity::CODE) as u8;
     let identity_length = 3;
     assert!(
         MultihashRef::from_slice(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -20,15 +20,14 @@ macro_rules! assert_encode {
                 hex,
                 "{:?} encodes correctly", stringify!($alg)
             );
-            {
-                let mut hasher = <$alg>::default();
-                &mut hasher.input($data);
-                assert_eq!(
-                    hasher.result().into_bytes(),
-                    hex,
-                    "{:?} encodes correctly", stringify!($alg)
-                )
-            }
+
+            let mut hasher = <$alg>::default();
+            &mut hasher.input($data);
+            assert_eq!(
+                hasher.result().into_bytes(),
+                hex,
+                "{:?} encodes correctly", stringify!($alg)
+            );
         )*
     }
 }
@@ -111,7 +110,7 @@ macro_rules! assert_roundtrip {
                 assert_eq!(
                     MultihashRef::from_slice(&hash).unwrap().algorithm(),
                     $alg::CODE
-                )
+                );
             }
         )*
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,12 +12,12 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
 }
 
 macro_rules! assert_encode {
-    {$( $alg:ident, $data:expr, $expect:expr; )*} => {
+    {$( $alg:ty, $data:expr, $expect:expr; )*} => {
         $(
             assert_eq!(
-                $alg::digest($data).into_bytes(),
+                <$alg>::digest($data).into_bytes(),
                 hex_to_bytes($expect),
-                "{:?} encodes correctly", $alg
+                "{:?} encodes correctly", stringify!($alg)
             );
         )*
     }
@@ -49,13 +49,13 @@ fn multihash_encode() {
 }
 
 macro_rules! assert_decode {
-    {$( $alg:ident, $hash:expr; )*} => {
+    {$( $alg:ty, $hash:expr; )*} => {
         $(
             let hash = hex_to_bytes($hash);
             assert_eq!(
                 MultihashRef::from_slice(&hash).unwrap().algorithm(),
-                $alg::CODE,
-                "{:?} decodes correctly", $alg
+                <$alg>::CODE,
+                "{:?} decodes correctly", stringify!($alg)
             );
         )*
     }
@@ -136,68 +136,76 @@ fn test_methods(hash: impl MultihashDigest, prefix: &str, digest: &str) {
 
 #[test]
 fn multihash_methods() {
-    test_methods(Identity, "000b", "68656c6c6f20776f726c64");
-    test_methods(Sha1, "1114", "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+    test_methods(Identity::default(), "000b", "68656c6c6f20776f726c64");
     test_methods(
-        Sha2_256,
+        Sha1::default(),
+        "1114",
+        "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+    );
+    test_methods(
+        Sha2_256::default(),
         "1220",
         "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
     );
     test_methods(
-        Sha2_512,
+        Sha2_512::default(),
         "1340",
         "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f");
     test_methods(
-        Sha3_224,
+        Sha3_224::default(),
         "171C",
         "dfb7f18c77e928bb56faeb2da27291bd790bc1045cde45f3210bb6c5",
     );
     test_methods(
-        Sha3_256,
+        Sha3_256::default(),
         "1620",
         "644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938",
     );
     test_methods(
-        Sha3_384,
+        Sha3_384::default(),
         "1530",
         "83bff28dde1b1bf5810071c6643c08e5b05bdb836effd70b403ea8ea0a634dc4997eb1053aa3593f590f9c63630dd90b");
     test_methods(
-        Sha3_512,
+        Sha3_512::default(),
         "1440",
         "840006653e9ac9e95117a15c915caab81662918e925de9e004f774ff82d7079a40d4d27b1b372657c61d46d470304c88c788b3a4527ad074d1dccbee5dbaa99a");
     test_methods(
-        Keccak224,
+        Keccak224::default(),
         "1A1C",
         "25f3ecfebabe99686282f57f5c9e1f18244cfee2813d33f955aae568",
     );
     test_methods(
-        Keccak256,
+        Keccak256::default(),
         "1B20",
         "47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad",
     );
     test_methods(
-        Keccak384,
+        Keccak384::default(),
         "1C30",
         "65fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f");
     test_methods(
-        Keccak512,
+        Keccak512::default(),
         "1D40",
         "3ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d");
     test_methods(
-        Blake2b512,
+        Blake2b512::default(),
         "c0e40240",
         "021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0");
     test_methods(
-        Blake2s256,
+        Blake2s256::default(),
         "e0e40220",
         "9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b",
     );
     test_methods(
-        Blake2b256,
+        Blake2b256::default(),
         "a0e40220",
         "256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610",
     );
-    test_methods(Blake2s128, "d0e40210", "37deae0226c30da2ab424a7b8ee14e83");
+    test_methods(
+        Blake2s128::default(),
+        "d0e40210",
+        "37deae0226c30da2ab424a7b8ee14e83",
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR does the following:

- extends `MultihashDigest` with an `input` and `result` method (borrowed from the `Digest` and `Input` traits) to support streaming
- implements the new methods for all existing codecs
  - this required changing their implementation to embed the existing digest, but the `impl Default` makes hasher construction easy
- drastically reduces the amount of repetition in the `impl Code` and `impl MultihashDigest`s using two local macros.
- replaces `Code::to_u64` and `Code::from_u64` with `From<Code> for u64` and `From<u64> for Code`

All the original tests still pass and the core API is mostly the same (with the exception of hasher construction) ideally satisfying the O in SOLID :grin: 

Let me know what y'all think!