### PR TITLE
 feat: use generics for custom code tables

### DIFF
--- a/src/arb.rs
+++ b/src/arb.rs
@@ -27,6 +27,6 @@ impl Arbitrary for Multihash {
         // encoding an actual random piece of data might be better than just choosing
         // random numbers of the appropriate size, since some hash algos might produce
         // a limited set of values
-        code.hasher().unwrap().digest(&data)
+        code.hasher().digest(&data)
     }
 }

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -131,7 +131,7 @@ pub type MultihashRef<'a> = MultihashRefGeneric<'a, Code>;
 /// );
 /// ```
 #[derive(Clone)]
-pub struct MultihashGeneric<T> {
+pub struct MultihashGeneric<T: TryFrom<u64>> {
     storage: Storage,
     // Use `PhantomData` in order to be able to make the `Multihash` struct take a generic
     _code: PhantomData<T>,
@@ -143,15 +143,15 @@ impl<T: TryFrom<u64>> fmt::Debug for MultihashGeneric<T> {
     }
 }
 
-impl<T> PartialEq for MultihashGeneric<T> {
+impl<T: TryFrom<u64>> PartialEq for MultihashGeneric<T> {
     fn eq(&self, other: &Self) -> bool {
         self.storage.bytes() == other.storage.bytes()
     }
 }
 
-impl<T> Eq for MultihashGeneric<T> {}
+impl<T: TryFrom<u64>> Eq for MultihashGeneric<T> {}
 
-impl<T> hash::Hash for MultihashGeneric<T> {
+impl<T: TryFrom<u64>> hash::Hash for MultihashGeneric<T> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.storage.bytes().hash(state);
     }
@@ -407,7 +407,7 @@ impl<'a, T: TryFrom<u64>> Into<Vec<u8>> for MultihashRefGeneric<'a, T> {
 }
 
 /// The `MultihashDigest` trait specifies an interface common for all multihash functions.
-pub trait MultihashDigest<T> {
+pub trait MultihashDigest<T: TryFrom<u64>> {
     /// The Mutlihash byte value.
     fn code(&self) -> T;
 
@@ -454,7 +454,7 @@ pub trait MultihashDigest<T> {
 /// let wrapped: Multihash = wrap(Code::Sha2_256, &digest);
 /// assert_eq!(wrapped.digest(), digest);
 /// ```
-pub fn wrap<T: Into<u64> + std::fmt::Debug>(code: T, data: &[u8]) -> MultihashGeneric<T> {
+pub fn wrap<T: Into<u64> + TryFrom<u64>>(code: T, data: &[u8]) -> MultihashGeneric<T> {
     let mut code_buf = varint_encode::u64_buffer();
     let code = varint_encode::u64(code.into(), &mut code_buf);
 

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -25,7 +25,7 @@ pub type MultihashRef<'a> = MultihashRefGeneric<'a, Code>;
 /// # Example
 ///
 /// ```
-/// use multihash::{wrap, MultihashDigest, MultihashGeneric};
+/// use multihash::{wrap, MultihashGeneric};
 /// use std::convert::TryFrom;
 ///
 /// #[derive(Debug)]

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -222,7 +222,7 @@ impl<T: TryFrom<u64>> MultihashGeneric<T> {
     /// ```
     pub fn algorithm(&self) -> T
     where
-        <T as std::convert::TryFrom<u64>>::Error: std::fmt::Debug,
+        <T as TryFrom<u64>>::Error: std::fmt::Debug,
     {
         self.as_ref().algorithm()
     }
@@ -343,11 +343,11 @@ impl<'a, T: TryFrom<u64>> MultihashRefGeneric<'a, T> {
     /// ```
     pub fn algorithm(&self) -> T
     where
-        <T as std::convert::TryFrom<u64>>::Error: std::fmt::Debug,
+        <T as TryFrom<u64>>::Error: std::fmt::Debug,
     {
         let (rawcode, _bytes) =
             varint_decode::u64(&self.bytes).expect("multihash is known to be valid algorithm");
-        T::try_from(rawcode).unwrap()
+        T::try_from(rawcode).expect("multihash is known to be a valid algorithm")
     }
 
     /// Returns the hash digest.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ mod storage;
 #[cfg(any(test, feature = "test"))]
 mod arb;
 
-pub use digests::{wrap, Multihash, MultihashDigest, MultihashGeneric, MultihashRef};
+pub use digests::{
+    wrap, Multihash, MultihashDigest, MultihashGeneric, MultihashRef, MultihashRefGeneric,
+};
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,6 @@ mod storage;
 #[cfg(any(test, feature = "test"))]
 mod arb;
 
-pub use digests::{wrap, Multihash, MultihashDigest, MultihashRef};
+pub use digests::{wrap, Multihash, MultihashDigest, MultihashGeneric, MultihashRef};
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::*;

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,52 +1,20 @@
-use multihash::{wrap, Code, Multihash, MultihashDigest, Sha3_512};
+use std::convert::TryFrom;
+
+use multihash::{Code, Sha3_512};
 
 #[test]
 fn to_u64() {
     assert_eq!(<u64>::from(Code::Keccak256), 0x1b);
-    assert_eq!(<u64>::from(Code::Custom(0x1234)), 0x1234);
 }
 
 #[test]
 fn from_u64() {
-    assert_eq!(Code::from(0xb220), Code::Blake2b256);
-    assert_eq!(Code::from(0x0011_2233), Code::Custom(0x0011_2233));
+    assert_eq!(Code::try_from(0xb220), Ok(Code::Blake2b256));
 }
 
 #[test]
 fn hasher() {
     let expected = Sha3_512::digest(b"abcdefg");
-    let hasher = Code::Sha3_512.hasher().unwrap();
+    let hasher = Code::Sha3_512.hasher();
     assert_eq!(hasher.digest(b"abcdefg"), expected);
-    assert!(Code::Custom(0x2222).hasher().is_none());
-}
-
-#[test]
-fn custom_multihash_digest() {
-    #[derive(Clone, Debug)]
-    struct SameHash;
-    impl MultihashDigest for SameHash {
-        fn code(&self) -> Code {
-            Code::Custom(0x9999)
-        }
-
-        fn digest(&self, _data: &[u8]) -> Multihash {
-            let data = b"alwaysthesame";
-            wrap(Self.code(), data)
-        }
-
-        fn input(&mut self, _data: &[u8]) {}
-
-        fn result(self) -> Multihash {
-            Self::digest(&self, &[])
-        }
-
-        fn result_reset(&mut self) -> Multihash {
-            Self::digest(&self, &[])
-        }
-
-        fn reset(&mut self) {}
-    }
-
-    let my_hash = SameHash.digest(b"abc");
-    assert_eq!(my_hash.digest(), b"alwaysthesame");
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -287,3 +287,19 @@ fn multihash_ref_errors() {
         "Should error on wrong hash length"
     );
 }
+
+#[test]
+fn wrap() {
+    let mh = Sha2_256::digest(b"hello world");
+    let digest = mh.digest();
+    let wrapped: Multihash = multihash::wrap(Code::Sha2_256, &digest);
+    assert_eq!(wrapped.algorithm(), Code::Sha2_256);
+}
+
+#[test]
+fn wrap_generic() {
+    let mh = Sha2_256::digest(b"hello world");
+    let digest = mh.digest();
+    let wrapped: MultihashGeneric<u64> = multihash::wrap(124, &digest);
+    assert_eq!(wrapped.algorithm(), 124);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -127,7 +127,7 @@ fn assert_roundtrip() {
 }
 
 /// Testing the public interface of `Multihash` and `MultihashRef`
-fn test_methods(hash: impl MultihashDigest, prefix: &str, digest: &str) {
+fn test_methods(hash: impl MultihashDigest<Code>, prefix: &str, digest: &str) {
     let expected_bytes = hex_to_bytes(&format!("{}{}", prefix, digest));
     let multihash = hash.digest(b"hello world");
     assert_eq!(
@@ -234,21 +234,6 @@ fn test_long_identity_hash() {
     let input = b"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz";
     let multihash = Identity::digest(input);
     assert_eq!(multihash.digest().to_vec(), input.to_vec());
-}
-
-#[test]
-fn custom_multihash() {
-    let code = Code::Custom(0x1234);
-    let data = b"abcde".to_vec();
-    let multihash = wrap(code, &data);
-
-    assert_eq!(
-        multihash.as_bytes(),
-        &[0xb4, 0x24, 0x05, 0x61, 0x62, 0x63, 0x64, 0x65]
-    );
-    assert_eq!(multihash.algorithm(), code);
-    assert_eq!(<u64>::from(multihash.algorithm()), 0x1234);
-    assert_eq!(multihash.digest(), b"abcde");
 }
 
 #[test]


### PR DESCRIPTION
With generics it is now possible to have your own code tables. Most users
won't need those, hence there are type aliases to make this library easy
to use with the default case.

This doesn't commit doesn't change the API of `Multihash` or `MultihashRef`,
but the `MultihashDigest` trait now needs a generic type, usually
`MultihashDigest<Code>`.

BREAKING CHANGE: `MultihashDigest` needs a generic now

If you have used `MultihashDigest` you now need to use it as `MultihashDigest<Code>`.