### PR TITLE
feat: implement `hasher()` as `From` to `MultihashDigest<Code>`

### DIFF
--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,7 +1,7 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-use crate::{Code, Code::*, Multihash};
+use crate::{Code, Code::*, Multihash, MultihashDigest};
 
 const HASHES: [Code; 16] = [
     Identity, Sha1, Sha2_256, Sha2_512, Sha3_512, Sha3_384, Sha3_256, Sha3_224, Keccak224,
@@ -27,6 +27,6 @@ impl Arbitrary for Multihash {
         // encoding an actual random piece of data might be better than just choosing
         // random numbers of the appropriate size, since some hash algos might produce
         // a limited set of values
-        code.hasher().digest(&data)
+        Box::<dyn MultihashDigest<Code>>::from(code).digest(&data)
     }
 }

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -17,6 +17,16 @@ pub type Multihash = MultihashGeneric<Code>;
 /// This type is using the default Multihash code table
 pub type MultihashRef<'a> = MultihashRefGeneric<'a, Code>;
 
+/// This type makes it easier to interact with hashers
+///
+/// # Example
+///
+/// ```no-run
+/// let hasher1: BoxedMultihashDigest = Code::Sha3_512.into();
+/// let hasher2: BoxedMultihashDigest<_> = MyCodecTable::MyHash.into();
+/// ```
+pub type BoxedMultihashDigest<T = Code> = Box<dyn MultihashDigest<T>>;
+
 /// Representation of a valid multihash. This enforces validity on construction,
 /// so it can be assumed this is always a valid multihash.
 ///
@@ -407,7 +417,7 @@ impl<'a, T: TryFrom<u64>> Into<Vec<u8>> for MultihashRefGeneric<'a, T> {
 }
 
 /// The `MultihashDigest` trait specifies an interface common for all multihash functions.
-pub trait MultihashDigest<T = Code>
+pub trait MultihashDigest<T>
 where
     T: TryFrom<u64>,
 {

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -407,7 +407,10 @@ impl<'a, T: TryFrom<u64>> Into<Vec<u8>> for MultihashRefGeneric<'a, T> {
 }
 
 /// The `MultihashDigest` trait specifies an interface common for all multihash functions.
-pub trait MultihashDigest<T: TryFrom<u64>> {
+pub trait MultihashDigest<T = Code>
+where
+    T: TryFrom<u64>,
+{
     /// The Mutlihash byte value.
     fn code(&self) -> T;
 

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -23,13 +23,10 @@ macro_rules! impl_code {
             )*
         }
 
-        impl Code {
-            /// Return the hasher that is used to create a hash with this code.
-            ///
-            /// If a custom code is used, `None` is returned.
-            pub fn hasher(&self) -> Box<dyn MultihashDigest<Code>> {
-                match *self {
-                    $(Self::$name => Box::new($name::default()),)*
+        impl From<Code> for Box<dyn MultihashDigest<Code>> {
+            fn from(code: Code) -> Self {
+                match code {
+                    $(Code::$name => Box::new($name::default()),)*
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ mod storage;
 mod arb;
 
 pub use digests::{
-    wrap, Multihash, MultihashDigest, MultihashGeneric, MultihashRef, MultihashRefGeneric,
+    wrap, BoxedMultihashDigest, Multihash, MultihashDigest, MultihashGeneric, MultihashRef,
+    MultihashRefGeneric,
 };
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::*;

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use multihash::{Code, MultihashDigest, Sha3_512};
+use multihash::{wrap, Code, MultihashDigest, MultihashGeneric, Sha3_512};
 
 #[test]
 fn to_u64() {
@@ -16,5 +16,80 @@ fn from_u64() {
 fn hasher() {
     let expected = Sha3_512::digest(b"abcdefg");
     let hasher = Box::<dyn MultihashDigest>::from(Code::Sha3_512);
+    assert_eq!(hasher.digest(b"abcdefg"), expected);
+}
+
+#[test]
+fn hasher_custom_codes() {
+    enum MyCodeTable {
+        Foo = 1,
+        Bar = 2,
+    }
+
+    impl From<MyCodeTable> for u64 {
+        /// Return the code as integer value.
+        fn from(code: MyCodeTable) -> Self {
+            code as _
+        }
+    }
+
+    impl TryFrom<u64> for MyCodeTable {
+        type Error = String;
+
+        /// Return the `Code` based on the integer value. Error if no matching code exists.
+        fn try_from(raw: u64) -> Result<Self, Self::Error> {
+            match raw {
+                1 => Ok(MyCodeTable::Foo),
+                2 => Ok(MyCodeTable::Bar),
+                _ => Err("Cannot convert".to_string()),
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct SameHash;
+    impl SameHash {
+        pub const CODE: MyCodeTable = MyCodeTable::Foo;
+        /// Hash some input and return the sha1 digest.
+        pub fn digest(_data: &[u8]) -> MultihashGeneric<MyCodeTable> {
+            let digest = b"alwaysthesame";
+            wrap(Self::CODE, digest)
+        }
+    }
+
+    impl MultihashDigest<MyCodeTable> for SameHash {
+        #[inline]
+        fn code(&self) -> MyCodeTable {
+            Self::CODE
+        }
+        #[inline]
+        fn digest(&self, data: &[u8]) -> MultihashGeneric<MyCodeTable> {
+            Self::digest(data)
+        }
+        #[inline]
+        fn input(&mut self, _data: &[u8]) {}
+        #[inline]
+        fn result(self) -> MultihashGeneric<MyCodeTable> {
+            wrap(Self::CODE, b"alwaysthesame")
+        }
+        #[inline]
+        fn result_reset(&mut self) -> MultihashGeneric<MyCodeTable> {
+            wrap(Self::CODE, b"")
+        }
+        #[inline]
+        fn reset(&mut self) {}
+    }
+
+    impl From<MyCodeTable> for Box<dyn MultihashDigest<MyCodeTable>> {
+        fn from(code: MyCodeTable) -> Self {
+            match code {
+                MyCodeTable::Foo => Box::new(SameHash::default()),
+                MyCodeTable::Bar => Box::new(SameHash::default()),
+            }
+        }
+    }
+
+    let expected = SameHash::digest(b"abcdefg");
+    let hasher = Box::<dyn MultihashDigest<_>>::from(MyCodeTable::Foo);
     assert_eq!(hasher.digest(b"abcdefg"), expected);
 }

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use multihash::{wrap, Code, MultihashDigest, MultihashGeneric, Sha3_512};
+use multihash::{wrap, BoxedMultihashDigest, Code, MultihashDigest, MultihashGeneric, Sha3_512};
 
 #[test]
 fn to_u64() {
@@ -15,7 +15,7 @@ fn from_u64() {
 #[test]
 fn hasher() {
     let expected = Sha3_512::digest(b"abcdefg");
-    let hasher = Box::<dyn MultihashDigest>::from(Code::Sha3_512);
+    let hasher: BoxedMultihashDigest = Code::Sha3_512.into();
     assert_eq!(hasher.digest(b"abcdefg"), expected);
 }
 
@@ -80,7 +80,7 @@ fn hasher_custom_codes() {
         fn reset(&mut self) {}
     }
 
-    impl From<MyCodeTable> for Box<dyn MultihashDigest<MyCodeTable>> {
+    impl From<MyCodeTable> for BoxedMultihashDigest<MyCodeTable> {
         fn from(code: MyCodeTable) -> Self {
             match code {
                 MyCodeTable::Foo => Box::new(SameHash::default()),
@@ -90,6 +90,6 @@ fn hasher_custom_codes() {
     }
 
     let expected = SameHash::digest(b"abcdefg");
-    let hasher = Box::<dyn MultihashDigest<_>>::from(MyCodeTable::Foo);
+    let hasher: BoxedMultihashDigest<_> = MyCodeTable::Foo.into();
     assert_eq!(hasher.digest(b"abcdefg"), expected);
 }

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -15,6 +15,6 @@ fn from_u64() {
 #[test]
 fn hasher() {
     let expected = Sha3_512::digest(b"abcdefg");
-    let hasher = Box::<dyn MultihashDigest<Code>>::from(Code::Sha3_512);
+    let hasher = Box::<dyn MultihashDigest>::from(Code::Sha3_512);
     assert_eq!(hasher.digest(b"abcdefg"), expected);
 }

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use multihash::{Code, Sha3_512};
+use multihash::{Code, MultihashDigest, Sha3_512};
 
 #[test]
 fn to_u64() {
@@ -15,6 +15,6 @@ fn from_u64() {
 #[test]
 fn hasher() {
     let expected = Sha3_512::digest(b"abcdefg");
-    let hasher = Code::Sha3_512.hasher();
+    let hasher = Box::<dyn MultihashDigest<Code>>::from(Code::Sha3_512);
     assert_eq!(hasher.digest(b"abcdefg"), expected);
 }


### PR DESCRIPTION
BREAKING CHANGE: Instead of calling `hasher()` use `from()` instead

Prior to this change, your code looked like this:

    let hasher = Code::Sha3_512.hasher();

Now it is:

    let hasher = Box::<dyn MultihashDigest<Code>>::from(Code::Sha3_512);

I tend to use the (Try)From trait everywhere these days, so please be critical if it doesn't make sense (though in this case I really like it).