### PR TITLE
remove unnecessary TryFrom error bounds

### DIFF
--- a/src/digests.rs
+++ b/src/digests.rs
@@ -352,8 +352,7 @@ impl<'a, T: TryFrom<u64>> MultihashRefGeneric<'a, T> {
         let (rawcode, _bytes) =
             varint_decode::u64(&self.bytes).expect("multihash is known to be valid algorithm");
         T::try_from(rawcode)
-            .or_else(|_| Err("Should not occur as multihash is known to be valid"))
-            .unwrap()
+            .unwrap_or_else(|_| panic!("Should not occur as multihash is known to be valid"))
     }
 
     /// Returns the hash digest.

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -230,10 +230,7 @@ impl<T: TryFrom<u64>> MultihashGeneric<T> {
     /// let mh = Sha2_256::digest(b"hello world");
     /// assert_eq!(mh.algorithm(), Code::Sha2_256);
     /// ```
-    pub fn algorithm(&self) -> T
-    where
-        <T as TryFrom<u64>>::Error: std::fmt::Debug,
-    {
+    pub fn algorithm(&self) -> T {
         self.as_ref().algorithm()
     }
 
@@ -351,13 +348,12 @@ impl<'a, T: TryFrom<u64>> MultihashRefGeneric<'a, T> {
     /// let mh2 = MultihashRef::from_slice(&mh).unwrap();
     /// assert_eq!(mh2.algorithm(), Code::Sha2_256);
     /// ```
-    pub fn algorithm(&self) -> T
-    where
-        <T as TryFrom<u64>>::Error: std::fmt::Debug,
-    {
+    pub fn algorithm(&self) -> T {
         let (rawcode, _bytes) =
             varint_decode::u64(&self.bytes).expect("multihash is known to be valid algorithm");
-        T::try_from(rawcode).expect("multihash is known to be a valid algorithm")
+        T::try_from(rawcode)
+            .or_else(|_| Err("Should not occur as multihash is known to be valid"))
+            .unwrap()
     }
 
     /// Returns the hash digest.


### PR DESCRIPTION
The only reason these bounds are necessary are because in `MultihashRefGeneric::algorithm`, `expect` requires it - however, because the error should never even occur, it shouldn't really matter what error we panic with so long as its not completely useless, and thus the method doesn't need to require these bounds.

I've correspondingly opened a PR [1] in rust-cid to remove those unnecessary bounds from the `CidGeneric` type.

[1] See https://github.com/multiformats/rust-cid/pull/60 for the full consequences of the change.