### PR TITLE
fix: implement `digest` on the code table as trait

### DIFF
--- a/src/digests.rs
+++ b/src/digests.rs
@@ -412,13 +412,24 @@ impl<'a, T: TryFrom<u64>> Into<Vec<u8>> for MultihashRefGeneric<'a, T> {
 }
 
 /// The `Multihasher` trait specifies an interface common for all multihash functions
-/// that does not require allocating a `Box<dyn MultihashDigest<T>>`.
+/// that does not require allocating a `Box<dyn MultihashDigest<T>>`. It is usually implemented
+/// for hahsing implementations.
 pub trait Multihasher<T: TryFrom<u64> + Copy> {
     /// The multihash code.
     const CODE: T;
 
     /// Hash some input and return the digest.
     fn digest(data: &[u8]) -> MultihashGeneric<T>;
+}
+
+/// The `DigestFromCode` returns a digest based on a code from a Multihash Code Table. It is
+/// usually implemented for such a Multihash Code Table.
+pub trait DigestFromCode
+where
+    Self: TryFrom<u64> + Copy,
+{
+    /// Hash some input and return the digest.
+    fn digest(&self, data: &[u8]) -> MultihashGeneric<Self>;
 }
 
 /// The `MultihashDigest` trait specifies an interface common for all multihash functions.

--- a/src/hashes.rs
+++ b/src/hashes.rs
@@ -4,7 +4,7 @@ use blake2b_simd::{Params as Blake2bParams, State as Blake2b};
 use blake2s_simd::{Params as Blake2sParams, State as Blake2s};
 use digest::Digest;
 
-use crate::digests::{wrap, Multihash, MultihashDigest, Multihasher};
+use crate::digests::{wrap, DigestFromCode, Multihash, MultihashDigest, Multihasher};
 use crate::errors::DecodeError;
 
 #[doc(hidden)]
@@ -23,13 +23,12 @@ macro_rules! impl_code {
             )*
         }
 
-        impl Code {
-            /// Hash some input and return the raw binary digest.
-            pub fn digest(&self, data: &[u8]) -> Multihash {
-                match self {
-                    $(Self::$name => $name::digest(data),)*
-                }
-            }
+        impl DigestFromCode for Code {
+               fn digest(&self, data: &[u8]) -> Multihash {
+                   match self {
+                       $(Self::$name => $name::digest(data),)*
+                   }
+               }
         }
 
         impl From<Code> for Box<dyn MultihashDigest<Code>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ mod storage;
 mod arb;
 
 pub use digests::{
-    wrap, BoxedMultihashDigest, Multihash, MultihashDigest, MultihashGeneric, MultihashRef,
-    MultihashRefGeneric, Multihasher,
+    wrap, BoxedMultihashDigest, DigestFromCode, Multihash, MultihashDigest, MultihashGeneric,
+    MultihashRef, MultihashRefGeneric, Multihasher,
 };
 pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::*;

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -1,7 +1,10 @@
 use std::convert::TryFrom;
 
-use multihash::{wrap, BoxedMultihashDigest, Code, MultihashDigest, MultihashGeneric, Sha3_512};
+use multihash::{
+    wrap, BoxedMultihashDigest, Code, DigestFromCode, MultihashDigest, MultihashGeneric, Sha3_512,
+};
 
+#[derive(Clone, Copy)]
 enum MyCodeTable {
     Foo = 1,
     Bar = 2,
@@ -92,4 +95,19 @@ fn hasher_custom_codes() {
     let expected = SameHash::digest(b"abcdefg");
     let hasher: BoxedMultihashDigest<_> = MyCodeTable::Foo.into();
     assert_eq!(hasher.digest(b"abcdefg"), expected);
+}
+
+#[test]
+fn digest_from_code() {
+    impl DigestFromCode for MyCodeTable {
+        fn digest(&self, data: &[u8]) -> MultihashGeneric<Self> {
+            match self {
+                MyCodeTable::Foo => SameHash::digest(data),
+                MyCodeTable::Bar => SameHash::digest(data),
+            }
+        }
+    }
+
+    let expected = SameHash::digest(b"abcdefg");
+    assert_eq!(MyCodeTable::Bar.digest(b"abcdefg"), expected);
 }

--- a/tests/hashes.rs
+++ b/tests/hashes.rs
@@ -2,6 +2,65 @@ use std::convert::TryFrom;
 
 use multihash::{wrap, BoxedMultihashDigest, Code, MultihashDigest, MultihashGeneric, Sha3_512};
 
+enum MyCodeTable {
+    Foo = 1,
+    Bar = 2,
+}
+
+impl From<MyCodeTable> for u64 {
+    /// Return the code as integer value.
+    fn from(code: MyCodeTable) -> Self {
+        code as _
+    }
+}
+
+impl TryFrom<u64> for MyCodeTable {
+    type Error = String;
+
+    /// Return the `Code` based on the integer value. Error if no matching code exists.
+    fn try_from(raw: u64) -> Result<Self, Self::Error> {
+        match raw {
+            1 => Ok(MyCodeTable::Foo),
+            2 => Ok(MyCodeTable::Bar),
+            _ => Err("Cannot convert".to_string()),
+        }
+    }
+}
+
+#[derive(Default)]
+struct SameHash;
+impl SameHash {
+    pub const CODE: MyCodeTable = MyCodeTable::Foo;
+    /// Hash some input and return the sha1 digest.
+    pub fn digest(_data: &[u8]) -> MultihashGeneric<MyCodeTable> {
+        let digest = b"alwaysthesame";
+        wrap(Self::CODE, digest)
+    }
+}
+
+impl MultihashDigest<MyCodeTable> for SameHash {
+    #[inline]
+    fn code(&self) -> MyCodeTable {
+        Self::CODE
+    }
+    #[inline]
+    fn digest(&self, data: &[u8]) -> MultihashGeneric<MyCodeTable> {
+        Self::digest(data)
+    }
+    #[inline]
+    fn input(&mut self, _data: &[u8]) {}
+    #[inline]
+    fn result(self) -> MultihashGeneric<MyCodeTable> {
+        wrap(Self::CODE, b"alwaysthesame")
+    }
+    #[inline]
+    fn result_reset(&mut self) -> MultihashGeneric<MyCodeTable> {
+        wrap(Self::CODE, b"")
+    }
+    #[inline]
+    fn reset(&mut self) {}
+}
+
 #[test]
 fn to_u64() {
     assert_eq!(<u64>::from(Code::Keccak256), 0x1b);
@@ -21,65 +80,6 @@ fn hasher() {
 
 #[test]
 fn hasher_custom_codes() {
-    enum MyCodeTable {
-        Foo = 1,
-        Bar = 2,
-    }
-
-    impl From<MyCodeTable> for u64 {
-        /// Return the code as integer value.
-        fn from(code: MyCodeTable) -> Self {
-            code as _
-        }
-    }
-
-    impl TryFrom<u64> for MyCodeTable {
-        type Error = String;
-
-        /// Return the `Code` based on the integer value. Error if no matching code exists.
-        fn try_from(raw: u64) -> Result<Self, Self::Error> {
-            match raw {
-                1 => Ok(MyCodeTable::Foo),
-                2 => Ok(MyCodeTable::Bar),
-                _ => Err("Cannot convert".to_string()),
-            }
-        }
-    }
-
-    #[derive(Default)]
-    struct SameHash;
-    impl SameHash {
-        pub const CODE: MyCodeTable = MyCodeTable::Foo;
-        /// Hash some input and return the sha1 digest.
-        pub fn digest(_data: &[u8]) -> MultihashGeneric<MyCodeTable> {
-            let digest = b"alwaysthesame";
-            wrap(Self::CODE, digest)
-        }
-    }
-
-    impl MultihashDigest<MyCodeTable> for SameHash {
-        #[inline]
-        fn code(&self) -> MyCodeTable {
-            Self::CODE
-        }
-        #[inline]
-        fn digest(&self, data: &[u8]) -> MultihashGeneric<MyCodeTable> {
-            Self::digest(data)
-        }
-        #[inline]
-        fn input(&mut self, _data: &[u8]) {}
-        #[inline]
-        fn result(self) -> MultihashGeneric<MyCodeTable> {
-            wrap(Self::CODE, b"alwaysthesame")
-        }
-        #[inline]
-        fn result_reset(&mut self) -> MultihashGeneric<MyCodeTable> {
-            wrap(Self::CODE, b"")
-        }
-        #[inline]
-        fn reset(&mut self) {}
-    }
-
     impl From<MyCodeTable> for BoxedMultihashDigest<MyCodeTable> {
         fn from(code: MyCodeTable) -> Self {
             match code {


### PR DESCRIPTION
Instead of having `digest()` directly on the implementation, implement
it via trait. This way the digest can be used as trait bound.

BREAKING CHANGE: You need to import the `DigestFromCode` trait if you
use `digest()` on a Multihash Code.