### PR TITLE
fix: make sure Multihashes are always valid

### DIFF
--- a/src/digests.rs
+++ b/src/digests.rs
@@ -321,7 +321,9 @@ impl<'a, T: TryFrom<u64>> MultihashRefGeneric<'a, T> {
             return Err(DecodeError::BadInputLength);
         }
 
-        let (_code, bytes) = varint_decode::u64(&input).map_err(|_| DecodeError::BadInputLength)?;
+        let (code, bytes) = varint_decode::u64(&input).map_err(|_| DecodeError::BadInputLength)?;
+        // Make sure it's a code that is part of the codec table
+        T::try_from(code).map_err(|_| DecodeError::UnknownCode)?;
 
         let (hash_len, bytes) =
             varint_decode::u64(&bytes).map_err(|_| DecodeError::BadInputLength)?;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -286,6 +286,14 @@ fn multihash_ref_errors() {
         MultihashRef::from_slice(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),
         "Should error on wrong hash length"
     );
+
+    let unsupported_code = 0x04;
+    let hash_length = 3;
+    assert_eq!(
+        MultihashRef::from_slice(&[unsupported_code, hash_length, 1, 2, 3]),
+        Err(DecodeError::UnknownCode),
+        "Should error on codes that are not part of the code table"
+    );
 }
 
 #[test]


### PR DESCRIPTION
When a Multihash is created, we make sure that the supplied code is supported,
hence part of the code table. Throw an error if a passed in multihash contains
an unsupported code.

Fixes #70.