### PR TITLE
Blake3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 blake2b_simd = { version = "0.5.9", default-features = false }
 blake2s_simd = { version = "0.5.9", default-features = false }
+blake3 = "0.3.5"
 digest = { version = "0.8", default-features = false }
 sha-1 = { version = "0.8", default-features = false }
 sha2 = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand = { version = "0.7.3", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+hex = "0.4.2"
 quickcheck = "0.9.2"
 rand = "0.7.3"
 

--- a/benches/multihash.rs
+++ b/benches/multihash.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
 use multihash::{
-    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Identity, Keccak224, Keccak256, Keccak384,
+    Blake3, Blake2b256, Blake2b512, Blake2s128, Blake2s256, Identity, Keccak224, Keccak256, Keccak384,
     Keccak512, MultihashDigest, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
 };
 
@@ -61,6 +61,7 @@ fn bench_digest(c: &mut Criterion) {
         "blake2b_512" => Blake2b512, &data
         "blake2s_128" => Blake2s128, &data
         "blake2s_256" => Blake2s256, &data
+        "blake3" => Blake3, &data
     );
 }
 
@@ -85,6 +86,7 @@ fn bench_stream(c: &mut Criterion) {
         "blake2b_512" => Blake2b512, &data
         "blake2s_128" => Blake2s128, &data
         "blake2s_256" => Blake2s256, &data
+        "blake3" => Blake3, &data
     );
 }
 

--- a/benches/multihash.rs
+++ b/benches/multihash.rs
@@ -2,8 +2,9 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::Rng;
 
 use multihash::{
-    Blake3, Blake2b256, Blake2b512, Blake2s128, Blake2s256, Identity, Keccak224, Keccak256, Keccak384,
-    Keccak512, MultihashDigest, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
+    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Blake3, Identity, Keccak224, Keccak256,
+    Keccak384, Keccak512, MultihashDigest, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256, Sha3_384,
+    Sha3_512,
 };
 
 macro_rules! group_digest {

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -3,9 +3,9 @@ use rand::seq::SliceRandom;
 
 use crate::{Code, Code::*, Multihash, MultihashDigest};
 
-const HASHES: [Code; 16] = [
+const HASHES: [Code; 17] = [
     Identity, Sha1, Sha2_256, Sha2_512, Sha3_512, Sha3_384, Sha3_256, Sha3_224, Keccak224,
-    Keccak256, Keccak384, Keccak512, Blake2b256, Blake2b512, Blake2s128, Blake2s256,
+    Keccak256, Keccak384, Keccak512, Blake2b256, Blake2b512, Blake2s128, Blake2s256, Blake3,
 ];
 
 /// Generates a random hash algorithm.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -44,7 +44,7 @@ fn multihash_encode() {
         Blake2s256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
         Blake2b256, b"hello world", "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
         Blake2s128, b"hello world", "d0e4021037deae0226c30da2ab424a7b8ee14e83";
-        // Blake3, b"hello world", "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
+        Blake3, b"hello world", "1e20d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
     }
 }
 
@@ -81,7 +81,7 @@ fn assert_decode() {
         Blake2s256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
         Blake2b256, "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
         Blake2s128, "d0e4021037deae0226c30da2ab424a7b8ee14e83";
-        // Blake3, "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
+        Blake3, "1e20d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
     }
 }
 
@@ -216,6 +216,11 @@ fn multihash_methods() {
         Blake2s128::default(),
         "d0e40210",
         "37deae0226c30da2ab424a7b8ee14e83",
+    );
+    test_methods(
+        Blake3::default(),
+        "1e20",
+        "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24",
     );
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -55,6 +55,7 @@ fn multihash_encode() {
         Blake2s256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
         Blake2b256, b"hello world", "a0e40220256c83b297114d201b30179f3f0ef0cace9783622da5974326b436178aeef610";
         Blake2s128, b"hello world", "d0e4021037deae0226c30da2ab424a7b8ee14e83";
+        Blake3, b"hello world", "d74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24";
     }
 }
 


### PR DESCRIPTION
implements trivial support for [blake3](https://github.com/BLAKE3-team/BLAKE3) using the default 32 byte digest.

longer digests could be implemented using XOF with separate codes, or potentially passing in the desired length, neither of which is in this PR though. 

improvements could also be had with [rayon](https://crates.io/crates/rayon) using [join](https://docs.rs/blake3/0.3.5/blake3/join/index.html) but are again not in this PR.