### PR TITLE
feat: update digest, sha-1, sha2 and sha3 to v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 [dependencies]
 blake2b_simd = { version = "0.5.9", default-features = false }
 blake2s_simd = { version = "0.5.9", default-features = false }
-blake3 = "0.3.5"
-digest = { version = "0.8", default-features = false }
-sha-1 = { version = "0.8", default-features = false }
-sha2 = { version = "0.8", default-features = false }
-sha3 = { version = "0.8", default-features = false }
+blake3 = { version = "0.3.5", default-features = false }
+digest = { version = "0.9", default-features = false }
+sha-1 = { version = "0.9", default-features = false }
+sha2 = { version = "0.9", default-features = false }
+sha3 = { version = "0.9", default-features = false }
 unsigned-varint = "0.4"
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }

--- a/src/digests.rs
+++ b/src/digests.rs
@@ -435,7 +435,7 @@ pub trait MultihashDigest<T: TryFrom<u64>> {
     /// Panics if the digest length is bigger than 2^32. This only happens for identity hasing.
     fn digest(&self, data: &[u8]) -> MultihashGeneric<T>;
 
-    /// Digest input data.
+    /// Digest data, updating the internal state.
     ///
     /// This method can be called repeatedly for use with streaming messages.
     ///


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

~~**BREAKING CHANGE**: Rename some methods in the `MultihashDigest` trait~~
    
~~`input` ==> `update`~~
~~`result` ==> `finalize`~~
~~`result_reset` ==> `finalize_reset`~~