### PR TITLE
feat: update unsigned-varint to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ digest = { version = "0.9", default-features = false }
 sha-1 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 sha3 = { version = "0.9", default-features = false }
-unsigned-varint = "0.4"
+unsigned-varint = "0.5"
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
 


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

https://github.com/multiformats/rust-cid/pull/65#issuecomment-668335114

BTW, I think it's time to release a patch version before refactoring the `multihash`. (maybe also needs to release a patch version for `cid` to keep the `unsigned-varint` version consistent in the dependency tree)