### PR TITLE
fix: revive ordering of multihashes.

### DIFF
--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -73,7 +73,7 @@ pub trait MultihashCode:
 #[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
 #[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde-codec", serde(bound = "S: Size"))]
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Multihash<S: Size> {
     /// The code of the Multihash.
     code: u64,


### PR DESCRIPTION
https://github.com/multiformats/rust-multihash/commit/7a6933731e3cb8dcbd086668dc2375bccb337d1a
introduced order of multihashes. That got lost during the most recent
merge. This commit revives it again.