### PR TITLE
feat: rename MultihashCode to MultihashDigest

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use multihash::derive::Multihash;
-//! use multihash::{MultihashCode, U32, U64};
+//! use multihash::{MultihashDigest, U32, U64};
 //!
 //! #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
 //! #[mh(alloc_size = U64)]

--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -338,7 +338,7 @@ pub fn multihash(s: Structure) -> TokenStream {
     let from_digest = hashes.iter().map(|h| h.from_digest(&params));
 
     quote! {
-        impl #mh_crate::MultihashCode for #code_enum {
+        impl #mh_crate::MultihashDigest for #code_enum {
             type AllocSize = #alloc_size;
 
             fn digest(&self, input: &[u8]) -> #mh_crate::Multihash<Self::AllocSize> {
@@ -400,7 +400,7 @@ mod tests {
             }
         };
         let expected = quote! {
-            impl multihash::MultihashCode for Code {
+            impl multihash::MultihashDigest for Code {
                type AllocSize = U32;
 
                fn digest(&self, input: &[u8]) -> multihash::Multihash<Self::AllocSize> {

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use multihash::derive::Multihash;
 use multihash::typenum::{U20, U25, U64};
 use multihash::{
-    Digest, Error, Hasher, Multihash, MultihashCode, Sha2Digest, Sha2_256, Size, StatefulHasher,
+    Digest, Error, Hasher, Multihash, MultihashDigest, Sha2Digest, Sha2_256, Size, StatefulHasher,
 };
 
 // You can implement a custom hasher. This is a SHA2 256-bit hasher that returns a hash that is

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,7 +1,7 @@
 use quickcheck::{Arbitrary, Gen};
 use rand::seq::SliceRandom;
 
-use crate::{Code, Multihash, MultihashCode, U64};
+use crate::{Code, Multihash, MultihashDigest, U64};
 
 const HASHES: [Code; 15] = [
     Code::Sha2_256,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
 pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
-pub use crate::multihash::{Multihash, MultihashCode};
+pub use crate::multihash::{Multihash, MultihashDigest};
 pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_derive as derive;

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -11,7 +11,7 @@ use generic_array::{ArrayLength, GenericArray};
 /// It is usually implemented by a custom code table enum that derives the [`Multihash` derive].
 ///
 /// [`Multihash` derive]: crate::derive
-pub trait MultihashCode:
+pub trait MultihashDigest:
     TryFrom<u64> + Into<u64> + Send + Sync + Unpin + Copy + Eq + Debug + 'static
 {
     /// The maximum size a hash will allocate.
@@ -22,8 +22,8 @@ pub trait MultihashCode:
     /// # Example
     ///
     /// ```
-    /// // `Code` implements `MultihashCode`
-    /// use multihash::{Code, MultihashCode};
+    /// // `Code` implements `MultihashDigest`
+    /// use multihash::{Code, MultihashDigest};
     ///
     /// let hash = Code::Sha3_256.digest(b"Hello world!");
     /// println!("{:02x?}", hash);
@@ -35,7 +35,7 @@ pub trait MultihashCode:
     /// # Example
     ///
     /// ```
-    /// use multihash::{Code, MultihashCode, Sha3_256, StatefulHasher};
+    /// use multihash::{Code, MultihashDigest, Sha3_256, StatefulHasher};
     ///
     /// let mut hasher = Sha3_256::default();
     /// hasher.update(b"Hello world!");

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -76,7 +76,7 @@ mod tests {
     use super::*;
     use crate::hasher::Hasher;
     use crate::hasher_impl::sha3::{Sha3_256, Sha3_512};
-    use crate::multihash::MultihashCode;
+    use crate::multihash::MultihashDigest;
 
     #[test]
     fn test_hasher_256() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use multihash::{
     derive::Multihash, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128, Blake2s256,
     Blake2sDigest, Blake3Digest, Blake3_256, Digest, Error, Hasher, Identity256, IdentityDigest,
-    Keccak224, Keccak256, Keccak384, Keccak512, KeccakDigest, Multihash, MultihashCode, Sha1,
+    Keccak224, Keccak256, Keccak384, Keccak512, KeccakDigest, Multihash, MultihashDigest, Sha1,
     Sha1Digest, Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
     Size, StatefulHasher, Strobe256, Strobe512, StrobeDigest, U16, U20, U28, U32, U48, U64,
 };


### PR DESCRIPTION
While I was looking into upgrading libp2p to this version of multihash,
I realized that `MultihashCode` might not be such a good name for the
trait.

First of all, it's kind of a meaningless name. What does it actually do?
It does create digests, hence I think `MultihashDigest` is a better name.

Also `MultihashCode` can easily clash with other names. For example if
you have a custom Multihash code table, just calling it `Code` might be
a to generic name in case you want to have it as a top-level export. Then
`MultihashCode` might be a good name, but it would clash with the trait
name.

BREAKING CHANGE: The `MultihashCode` trait is now named `MultihashDigest`.