### PR TITLE
docs: clarify multihash-impl feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,11 @@
 //!
 //! The library has support for `no_std`, if you disable the `std` feature flag.
 //!
-//! The `multihash-impl` feature flag enables a default Multihash implementation that contains all
-//! bundled hashers (which may be disabled via the feature flags mentioned above). If only want a
-//! specific subset of hash algorithms or add one which isn't supporte by default, you will likely
-//! disable that feature and enable `derive` in order to be able to use the [`Multihash` derive].
+//! The `multihash-impl` feature flag enables a default Multihash implementation that contains some
+//! of the bundled hashers. If you want a different set of hash algorithms or add one which isn't
+//! supported by default, you will disable that feature. Intead enable the `derive` feature in
+//! order to be able to use the [`Multihash` derive], together with the features for the hashers
+//! you need.
 //!
 //! The `arb` feature flag enables the quickcheck arbitrary implementation for property based
 //! testing.

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -10,63 +10,48 @@ use multihash_derive::Multihash;
 #[mh(alloc_size = crate::U64)]
 pub enum Code {
     /// SHA-256 (32-byte hash size)
-    #[cfg(feature = "sha2")]
     #[mh(code = 0x12, hasher = crate::Sha2_256, digest = crate::Sha2Digest<crate::U32>)]
     Sha2_256,
     /// SHA-512 (64-byte hash size)
-    #[cfg(feature = "sha2")]
     #[mh(code = 0x13, hasher = crate::Sha2_512, digest = crate::Sha2Digest<crate::U64>)]
     Sha2_512,
     /// SHA3-224 (28-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x17, hasher = crate::Sha3_224, digest = crate::Sha3Digest<crate::U28>)]
     Sha3_224,
     /// SHA3-256 (32-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x16, hasher = crate::Sha3_256, digest = crate::Sha3Digest<crate::U32>)]
     Sha3_256,
     /// SHA3-384 (48-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x15, hasher = crate::Sha3_384, digest = crate::Sha3Digest<crate::U48>)]
     Sha3_384,
     /// SHA3-512 (64-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x14, hasher = crate::Sha3_512, digest = crate::Sha3Digest<crate::U64>)]
     Sha3_512,
     /// Keccak-224 (28-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x1a, hasher = crate::Keccak224, digest = crate::KeccakDigest<crate::U28>)]
     Keccak224,
     /// Keccak-256 (32-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x1b, hasher = crate::Keccak256, digest = crate::KeccakDigest<crate::U32>)]
     Keccak256,
     /// Keccak-384 (48-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x1c, hasher = crate::Keccak384, digest = crate::KeccakDigest<crate::U48>)]
     Keccak384,
     /// Keccak-512 (64-byte hash size)
-    #[cfg(feature = "sha3")]
     #[mh(code = 0x1d, hasher = crate::Keccak512, digest = crate::KeccakDigest<crate::U64>)]
     Keccak512,
     /// BLAKE2b-256 (32-byte hash size)
-    #[cfg(feature = "blake2b")]
     #[mh(code = 0xb220, hasher = crate::Blake2b256, digest = crate::Blake2bDigest<crate::U32>)]
     Blake2b256,
     /// BLAKE2b-512 (64-byte hash size)
-    #[cfg(feature = "blake2b")]
     #[mh(code = 0xb240, hasher = crate::Blake2b512, digest = crate::Blake2bDigest<crate::U64>)]
     Blake2b512,
     /// BLAKE2s-128 (16-byte hash size)
-    #[cfg(feature = "blake2s")]
     #[mh(code = 0xb250, hasher = crate::Blake2s128, digest = crate::Blake2sDigest<crate::U16>)]
     Blake2s128,
     /// BLAKE2s-256 (32-byte hash size)
-    #[cfg(feature = "blake2s")]
     #[mh(code = 0xb260, hasher = crate::Blake2s256, digest = crate::Blake2sDigest<crate::U32>)]
     Blake2s256,
     /// BLAKE3-256 (32-byte hash size)
-    #[cfg(feature = "blake3")]
     #[mh(code = 0x1e, hasher = crate::Blake3_256, digest = crate::Blake3Digest<crate::U32>)]
     Blake3_256,
 }


### PR DESCRIPTION
The `multihash-impl` feature enables all hashers, so there is no point
of checking if a hasher is enabled. If the `multihash-impl` feature is
disabled, the whole module won't be included.