### PR TITLE
feat: default code table can be changed at compile time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.11.0'
-          args: '-- --test-threads 1'
+          args: '--all-features -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,18 @@ documentation = "https://docs.rs/multihash/"
 edition = "2018"
 
 [features]
-default = ["std", "all", "derive", "multihash-impl"]
+default = ["std", "derive", "multihash-impl", "secure-hashes"]
 std = ["unsigned-varint/std", "multihash-derive/std"]
-multihash-impl = ["derive", "all"]
+multihash-impl = ["derive"]
 derive = ["multihash-derive"]
 arb = ["quickcheck", "rand"]
-all = ["blake2b", "blake2s", "blake3", "sha1", "sha2", "sha3", "strobe"]
+secure-hashes = ["blake2b", "blake2s", "blake3", "sha2", "sha3"]
 scale-codec = ["parity-scale-codec"]
 serde-codec = ["serde", "generic-array/serde"]
 
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]
+identity = []
 sha1 = ["digest", "sha-1"]
 sha2 = ["digest", "sha-2"]
 sha3 = ["digest", "sha-3"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,33 +3,51 @@
 //! Feature Flags
 //! -------------
 //!
-//! Multihash has lots of [feature flags], by default all features, except for `arb`, `scale-codec`
-//! and `serde-codec` are enabled.
+//! Multihash has lots of [feature flags], by default a table with cryptographically secure hashers
+//! is created.
 //!
-//! Some of the features are about specific hash functions, these are:
+//! Some of the features are about specific hash functions, these are ("default" marks the hashers
+//! that are enabled by default):
 //!
-//!  - `blake2b`: Enable Blake2b hashers
-//!  - `blake2s`: Enable Blake2s hashers
-//!  - `sha1`: Enable SHA-1 hashers
-//!  - `sha2`: Enable SHA-2 hashers
-//!  - `sha3`: Enable SHA-3 hashers
+//!  - `blake2b`: (default) Enable Blake2b hashers
+//!  - `blake2s`: (default) Enable Blake2s hashers
+//!  - `identity`: Enable the Identity hashers (using it is discouraged as it's not a hash function
+//!     in the sense that it produces a fixed sized output independent of the input size)
+//!  - `sha1`: Enable SHA-1 hasher
+//!  - `sha2`: (default) Enable SHA-2 hashers
+//!  - `sha3`: (default) Enable SHA-3 hashers
 //!  - `strobe`: Enable Strobe hashers
 //!
-//! In order to enable all hashers, you can set the `all` feature flag.
+//! In order to enable all cryptographically secure hashers, you can set the `secure-hashes`
+//! feature flag (enabled by default).
 //!
 //! The library has support for `no_std`, if you disable the `std` feature flag.
 //!
-//! The `multihash-impl` feature flag enables a default Multihash implementation that contains some
-//! of the bundled hashers. If you want a different set of hash algorithms or add one which isn't
-//! supported by default, you will disable that feature. Intead enable the `derive` feature in
-//! order to be able to use the [`Multihash` derive], together with the features for the hashers
-//! you need.
+//! The `multihash-impl` feature flag (enabled by default) enables a default Multihash
+//! implementation that contains some of the bundled hashers. If you want a different set of hash
+//! algorithms you can change this with enabled the corresponding features.
+//!
+//! For example if you only need SHA2 hasher, you could set the features in the `multihash`
+//! dependency like this:
+//!
+//! ```toml
+//! multihash = { version = …, default-features = false, features = ["std", "multihash-impl", "sha2"] }
+//! ```
+//!
+//! If you want to customize your code table even more, for example you want only one specific hash
+//! digest size and not whole family, you would only enable the `derive` feature (enabled by
+//! default), which enables the [`Multihash` derive], together with the hashers you want.
 //!
 //! The `arb` feature flag enables the quickcheck arbitrary implementation for property based
 //! testing.
 //!
+//! For serializing the multihash there is support for [Serde] via the `serde-codec` feature and
+//! the [SCALE Codec] via the `scale-codec` feature.
+//!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //! [`Multihash` derive]: crate::derive
+//! [Serde]: https://serde.rs
+//! [SCALE Codec]: https://github.com/paritytech/parity-scale-codec
 
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -10,50 +10,71 @@ use multihash_derive::Multihash;
 #[mh(alloc_size = crate::U64)]
 pub enum Code {
     /// SHA-256 (32-byte hash size)
+    #[cfg(feature = "sha2")]
     #[mh(code = 0x12, hasher = crate::Sha2_256, digest = crate::Sha2Digest<crate::U32>)]
     Sha2_256,
     /// SHA-512 (64-byte hash size)
+    #[cfg(feature = "sha2")]
     #[mh(code = 0x13, hasher = crate::Sha2_512, digest = crate::Sha2Digest<crate::U64>)]
     Sha2_512,
     /// SHA3-224 (28-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x17, hasher = crate::Sha3_224, digest = crate::Sha3Digest<crate::U28>)]
     Sha3_224,
     /// SHA3-256 (32-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x16, hasher = crate::Sha3_256, digest = crate::Sha3Digest<crate::U32>)]
     Sha3_256,
     /// SHA3-384 (48-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x15, hasher = crate::Sha3_384, digest = crate::Sha3Digest<crate::U48>)]
     Sha3_384,
     /// SHA3-512 (64-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x14, hasher = crate::Sha3_512, digest = crate::Sha3Digest<crate::U64>)]
     Sha3_512,
     /// Keccak-224 (28-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x1a, hasher = crate::Keccak224, digest = crate::KeccakDigest<crate::U28>)]
     Keccak224,
     /// Keccak-256 (32-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x1b, hasher = crate::Keccak256, digest = crate::KeccakDigest<crate::U32>)]
     Keccak256,
     /// Keccak-384 (48-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x1c, hasher = crate::Keccak384, digest = crate::KeccakDigest<crate::U48>)]
     Keccak384,
     /// Keccak-512 (64-byte hash size)
+    #[cfg(feature = "sha3")]
     #[mh(code = 0x1d, hasher = crate::Keccak512, digest = crate::KeccakDigest<crate::U64>)]
     Keccak512,
     /// BLAKE2b-256 (32-byte hash size)
+    #[cfg(feature = "blake2b")]
     #[mh(code = 0xb220, hasher = crate::Blake2b256, digest = crate::Blake2bDigest<crate::U32>)]
     Blake2b256,
     /// BLAKE2b-512 (64-byte hash size)
+    #[cfg(feature = "blake2b")]
     #[mh(code = 0xb240, hasher = crate::Blake2b512, digest = crate::Blake2bDigest<crate::U64>)]
     Blake2b512,
     /// BLAKE2s-128 (16-byte hash size)
+    #[cfg(feature = "blake2s")]
     #[mh(code = 0xb250, hasher = crate::Blake2s128, digest = crate::Blake2sDigest<crate::U16>)]
     Blake2s128,
     /// BLAKE2s-256 (32-byte hash size)
+    #[cfg(feature = "blake2s")]
     #[mh(code = 0xb260, hasher = crate::Blake2s256, digest = crate::Blake2sDigest<crate::U32>)]
     Blake2s256,
     /// BLAKE3-256 (32-byte hash size)
+    #[cfg(feature = "blake3")]
     #[mh(code = 0x1e, hasher = crate::Blake3_256, digest = crate::Blake3Digest<crate::U32>)]
     Blake3_256,
+
+    // The following hashes are not cryptographically secure hashes and are not enabled by default
+    /// Identity hash (max. 64 bytes)
+    #[cfg(feature = "identity")]
+    #[mh(code = 0x00, hasher = crate::IdentityHasher::<crate::U64>, digest = crate::IdentityDigest<crate::U64>)]
+    Identity,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It is now possible to change the contents of the default code table
with enabling/disabling various features. If you e.g. only need SHA2
hashes, you can specify that when you use the `multihash` dependency:

    multihash = {
        version = …,
        default-features = false,
        features = ["std", "multihash-impl", "sha2"]
    }

BREAKING CHANGE: Only secure hashers are enabled by default