### PR TITLE
feat: create Multihash that matches the code table

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,5 @@
-//! This proc macro derives a custom Multihash code table from a list of hashers.
+//! This proc macro derives a custom Multihash code table from a list of hashers. It also
+//! generates a public type called `Multihash` which corresponds to the specified `alloc_size`.
 //!
 //! The digests are stack allocated with a fixed size. That size needs to be big enough to hold any
 //! of the specified hash digests. This cannot be determined reliably on compile-time, hence it

--- a/examples/custom_table.rs
+++ b/examples/custom_table.rs
@@ -3,7 +3,8 @@ use std::convert::TryFrom;
 use multihash::derive::Multihash;
 use multihash::typenum::{U20, U25, U64};
 use multihash::{
-    Digest, Error, Hasher, Multihash, MultihashDigest, Sha2Digest, Sha2_256, Size, StatefulHasher,
+    Digest, Error, Hasher, MultihashDigest, MultihashGeneric, Sha2Digest, Sha2_256, Size,
+    StatefulHasher,
 };
 
 // You can implement a custom hasher. This is a SHA2 256-bit hasher that returns a hash that is
@@ -48,7 +49,7 @@ fn main() {
     // Sometimes you might not need to hash new data, you just want to get the information about
     // a Multihash.
     let truncated_sha2_bytes = truncated_sha2_hash.to_bytes();
-    let unknown_hash = Multihash::<U64>::from_bytes(&truncated_sha2_bytes).unwrap();
+    let unknown_hash = Multihash::from_bytes(&truncated_sha2_bytes).unwrap();
     println!("SHA2 256-bit hash truncated to 160 bits:");
     println!("  code: {:x?}", unknown_hash.code());
     println!("  size: {}", unknown_hash.size());

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -4,10 +4,10 @@ use rand::{
     Rng,
 };
 
-use crate::{Multihash, U64};
+use crate::{MultihashGeneric, U64};
 
 /// Generates a random valid multihash.
-impl Arbitrary for Multihash<U64> {
+impl Arbitrary for MultihashGeneric<U64> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         // In real world lower multihash codes are more likely to happen, hence distribute them
         // with bias towards smaller values.
@@ -29,6 +29,6 @@ impl Arbitrary for Multihash<U64> {
         let size = g.gen_range(0, 64);
         let mut data = [0; 64];
         g.fill_bytes(&mut data);
-        Multihash::wrap(code, &data[..size]).unwrap()
+        MultihashGeneric::wrap(code, &data[..size]).unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,13 +65,13 @@ pub use crate::error::{Error, Result};
 #[cfg(feature = "std")]
 pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
-pub use crate::multihash::{Multihash, MultihashDigest};
+pub use crate::multihash::{Multihash as MultihashGeneric, MultihashDigest};
 pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_derive as derive;
 
 #[cfg(feature = "multihash-impl")]
-pub use crate::multihash_impl::Code;
+pub use crate::multihash_impl::{Code, Multihash};
 
 #[cfg(feature = "blake2b")]
 pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bDigest, Blake2bHasher};

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -42,6 +42,7 @@ pub trait MultihashDigest:
     /// let hash = Code::multihash_from_digest(&hasher.finalize());
     /// println!("{:02x?}", hash);
     /// ```
+    #[allow(clippy::needless_lifetimes)]
     fn multihash_from_digest<'a, S, D>(digest: &'a D) -> Multihash<Self::AllocSize>
     where
         S: Size,
@@ -57,7 +58,7 @@ pub trait MultihashDigest:
 /// # Example
 ///
 /// ```
-/// use multihash::{Multihash, U64};
+/// use multihash::Multihash;
 ///
 /// const Sha3_256: u64 = 0x16;
 /// let digest_bytes = [
@@ -65,7 +66,7 @@ pub trait MultihashDigest:
 ///     0x76, 0x22, 0xf3, 0xca, 0x71, 0xfb, 0xa1, 0xd9, 0x72, 0xfd, 0x94, 0xa3, 0x1c, 0x3b, 0xfb,
 ///     0xf2, 0x4e, 0x39, 0x38,
 /// ];
-/// let mh = Multihash::<U64>::from_bytes(&digest_bytes).unwrap();
+/// let mh = Multihash::from_bytes(&digest_bytes).unwrap();
 /// assert_eq!(mh.code(), Sha3_256);
 /// assert_eq!(mh.size(), 32);
 /// assert_eq!(mh.digest(), &digest_bytes[2..]);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,9 +3,10 @@ use std::io::Cursor;
 use multihash::{
     derive::Multihash, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128, Blake2s256,
     Blake2sDigest, Blake3Digest, Blake3_256, Digest, Error, Hasher, Identity256, IdentityDigest,
-    Keccak224, Keccak256, Keccak384, Keccak512, KeccakDigest, Multihash, MultihashDigest, Sha1,
-    Sha1Digest, Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
-    Size, StatefulHasher, Strobe256, Strobe512, StrobeDigest, U16, U20, U28, U32, U48, U64,
+    Keccak224, Keccak256, Keccak384, Keccak512, KeccakDigest, MultihashDigest, MultihashGeneric,
+    Sha1, Sha1Digest, Sha2Digest, Sha2_256, Sha2_512, Sha3Digest, Sha3_224, Sha3_256, Sha3_384,
+    Sha3_512, Size, StatefulHasher, Strobe256, Strobe512, StrobeDigest, U16, U20, U28, U32, U48,
+    U64,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
@@ -113,7 +114,7 @@ macro_rules! assert_decode {
         $(
             let hash = hex::decode($hash).unwrap();
             assert_eq!(
-                Multihash::<U64>::from_bytes(&hash).unwrap().code(),
+                Multihash::from_bytes(&hash).unwrap().code(),
                 u64::from($code),
                 "{:?} decodes correctly", stringify!($code)
             );
@@ -152,7 +153,7 @@ macro_rules! assert_roundtrip {
             {
                 let hash = $code.digest(b"helloworld");
                 assert_eq!(
-                    Multihash::<U64>::from_bytes(&hash.to_bytes()).unwrap().code(),
+                    Multihash::from_bytes(&hash.to_bytes()).unwrap().code(),
                     hash.code()
                 );
             }
@@ -162,7 +163,7 @@ macro_rules! assert_roundtrip {
                 hasher.update(b"helloworld");
                 let hash = Code::multihash_from_digest(&hasher.finalize());
                 assert_eq!(
-                    Multihash::<U64>::from_bytes(&hash.to_bytes()).unwrap().code(),
+                    Multihash::from_bytes(&hash.to_bytes()).unwrap().code(),
                     hash.code()
                 );
             }
@@ -313,25 +314,25 @@ fn test_long_identity_hash() {
 #[test]
 fn multihash_errors() {
     assert!(
-        Multihash::<U64>::from_bytes(&[]).is_err(),
+        Multihash::from_bytes(&[]).is_err(),
         "Should error on empty data"
     );
     assert!(
-        Multihash::<U64>::from_bytes(&[1, 2, 3]).is_err(),
+        Multihash::from_bytes(&[1, 2, 3]).is_err(),
         "Should error on invalid multihash"
     );
     assert!(
-        Multihash::<U64>::from_bytes(&[1, 2, 3]).is_err(),
+        Multihash::from_bytes(&[1, 2, 3]).is_err(),
         "Should error on invalid prefix"
     );
     assert!(
-        Multihash::<U64>::from_bytes(&[0x12, 0x20, 0xff]).is_err(),
+        Multihash::from_bytes(&[0x12, 0x20, 0xff]).is_err(),
         "Should error on correct prefix with wrong digest"
     );
     let identity_code: u8 = 0x00;
     let identity_length = 3;
     assert!(
-        Multihash::<U64>::from_bytes(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),
+        Multihash::from_bytes(&[identity_code, identity_length, 1, 2, 3, 4]).is_err(),
         "Should error on wrong hash length"
     );
 }


### PR DESCRIPTION
Instead of only export the `Multihash` that is generic over the allocated
size, also expose `Multihash` that is created by the `Multihash` derive.

If the `multihash-impl` feature is enabled, also a `Multihash` with the
corresponding size gets exported.

BREAKING CHANGE: The `Multihash` which is generic over the size is now
called `MultihashGeneric`.