### PR TITLE
feat: implement std::io::Write trait for the hashers

### DIFF
--- a/derive/src/multihash.rs
+++ b/derive/src/multihash.rs
@@ -266,7 +266,7 @@ fn error_alloc_size(hashes: &[Hash], expected_alloc_size_type: &syn::Type) {
 
     let maybe_error: Result<(), ParseError> = hashes
         .iter()
-        .map(|hash| {
+        .try_for_each(|hash| {
             // The digest type must have a size parameter of the shape `U<number>`, else we error.
             match hash.digest.segments.last() {
                 Some(path_segment) => match &path_segment.arguments {
@@ -300,7 +300,7 @@ fn error_alloc_size(hashes: &[Hash], expected_alloc_size_type: &syn::Type) {
                 },
                 None => Err(ParseError(hash.digest.span())),
             }
-        }).collect();
+        });
 
     if let Err(_error) = maybe_error {
         let msg = "Invalid byte size. It must be a unsigned integer typenum, e.g. `U32`";

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -134,19 +134,3 @@ impl<T: StatefulHasher> Hasher for T {
         hasher.finalize()
     }
 }
-
-/// New type wrapper for a hasher that implements the `std::io::Write` trait.
-#[cfg(feature = "std")]
-pub struct WriteHasher<H: Hasher>(H);
-
-#[cfg(feature = "std")]
-impl<H: StatefulHasher> std::io::Write for WriteHasher<H> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.update(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,6 @@ mod multihash;
 mod multihash_impl;
 
 pub use crate::error::{Error, Result};
-#[cfg(feature = "std")]
-pub use crate::hasher::WriteHasher;
 pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
 pub use crate::multihash::{Multihash as MultihashGeneric, MultihashDigest};
 pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 use multihash::{
     derive::Multihash, Blake2b256, Blake2b512, Blake2bDigest, Blake2s128, Blake2s256,
@@ -161,6 +161,16 @@ macro_rules! assert_roundtrip {
             {
                 let mut hasher = <$alg>::default();
                 hasher.update(b"helloworld");
+                let hash = Code::multihash_from_digest(&hasher.finalize());
+                assert_eq!(
+                    Multihash::from_bytes(&hash.to_bytes()).unwrap().code(),
+                    hash.code()
+                );
+            }
+            // Hashing as `Write` implementation
+            {
+                let mut hasher = <$alg>::default();
+                hasher.write_all(b"helloworld").unwrap();
                 let hash = Code::multihash_from_digest(&hasher.finalize());
                 assert_eq!(
                     Multihash::from_bytes(&hash.to_bytes()).unwrap().code(),


### PR DESCRIPTION
Instead of having a (non-working) wrapper struct for implementing
std::io::Write for a hasher, implement it directly on the hasher
instead.

Closes #95.

@dvc94ch you implemented the original `WriteHasher` wrapper. Is there a reason to do it that way or was it just a different code base and this PR is a better implementation?