### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.116", optional = true, default-features = false, features = ["derive"] }
 multihash-derive = { version = "^0.7.1", path = "derive", default-features = false, optional = true }
-unsigned-varint = "0.5.1"
+unsigned-varint = "0.7.0"
 
 blake2b_simd = { version = "0.5.10", default-features = false, optional = true }
 blake2s_simd = { version = "0.5.10", default-features = false, optional = true }
@@ -47,7 +47,7 @@ digest = { version = "0.9.0", default-features = false, optional = true }
 sha-1 = { version = "0.9.1", default-features = false, optional = true }
 sha-2 = { version = "0.9.0", default-features = false, optional = true, package = "sha2" }
 sha-3 = { version = "0.9.0", default-features = false, optional = true, package = "sha3" }
-strobe-rs = { version = "0.5.4", optional = true }
+strobe-rs = { version = "0.6.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.3"


### PR DESCRIPTION
We now have dependabot, but as there are several outdated packages,
I thought I upgrade them once more manually.

`quickcheck` (and `rand`) are likely not upgraded until there is a good way
to generate ranges (see https://github.com/BurntSushi/quickcheck/issues/267
for more information).