### PR TITLE
lazy move to const generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ derive = ["multihash-derive"]
 arb = ["quickcheck", "rand"]
 secure-hashes = ["blake2b", "blake2s", "blake3", "sha2", "sha3"]
 scale-codec = ["parity-scale-codec"]
-serde-codec = ["serde", "generic-array/serde"]
+serde-codec = ["serde"]
 
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]
@@ -32,7 +32,6 @@ sha3 = ["digest", "sha-3"]
 strobe = ["strobe-rs"]
 
 [dependencies]
-generic-array = "0.14.4"
 parity-scale-codec = { version = "1.3.5", optional = true, default-features = false, features = ["derive"] }
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -4,10 +4,10 @@ use rand::{
     Rng,
 };
 
-use crate::{MultihashGeneric, U64};
+use crate::{MultihashGeneric};
 
 /// Generates a random valid multihash.
-impl Arbitrary for MultihashGeneric<U64> {
+impl Arbitrary for MultihashGeneric<64> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         // In real world lower multihash codes are more likely to happen, hence distribute them
         // with bias towards smaller values.

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -1,35 +1,38 @@
 use crate::error::Error;
-use crate::hasher::{Digest, Size, StatefulHasher};
+use crate::hasher::{Digest, StatefulHasher};
 use core::convert::TryFrom;
-use generic_array::GenericArray;
 
 macro_rules! derive_digest {
     ($name:ident) => {
         /// Multihash digest.
-        #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-        pub struct $name<S: Size>(GenericArray<u8, S>);
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        pub struct $name<const S: usize>([u8; S]);
 
-        impl<S: Size> Copy for $name<S> where S::ArrayType: Copy {}
+        impl<const S: usize> Default for $name<S> {
+            fn default() -> Self {
+                [0u8; S].into()
+            }
+        }
 
-        impl<S: Size> AsRef<[u8]> for $name<S> {
+        impl<const S: usize> AsRef<[u8]> for $name<S> {
             fn as_ref(&self) -> &[u8] {
                 &self.0
             }
         }
 
-        impl<S: Size> AsMut<[u8]> for $name<S> {
+        impl<const S: usize> AsMut<[u8]> for $name<S> {
             fn as_mut(&mut self) -> &mut [u8] {
                 &mut self.0
             }
         }
 
-        impl<S: Size> From<GenericArray<u8, S>> for $name<S> {
-            fn from(array: GenericArray<u8, S>) -> Self {
+        impl<const S: usize> From<[u8; S]> for $name<S> {
+            fn from(array: [u8; S]) -> Self {
                 Self(array)
             }
         }
 
-        impl<S: Size> From<$name<S>> for GenericArray<u8, S> {
+        impl<const S: usize> From<$name<S>> for [u8; S] {
             fn from(digest: $name<S>) -> Self {
                 digest.0
             }
@@ -38,7 +41,7 @@ macro_rules! derive_digest {
         /// Convert slice to `Digest`.
         ///
         /// It errors when the length of the slice does not match the size of the `Digest`.
-        impl<S: Size> TryFrom<&[u8]> for $name<S> {
+        impl<const S: usize> TryFrom<&[u8]> for $name<S> {
             type Error = Error;
 
             fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
@@ -46,14 +49,14 @@ macro_rules! derive_digest {
             }
         }
 
-        impl<S: Size> Digest<S> for $name<S> {}
+        impl<const S: usize> Digest<S> for $name<S> {}
     };
 }
 
 macro_rules! derive_write {
     ($name:ident) => {
         #[cfg(feature = "std")]
-        impl<S: Size> std::io::Write for $name<S> {
+        impl<const S: usize> std::io::Write for $name<S> {
             fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
                 self.update(buf);
                 Ok(buf.len())
@@ -73,25 +76,22 @@ macro_rules! derive_hasher_blake {
 
         /// Multihash hasher.
         #[derive(Debug)]
-        pub struct $name<S: Size> {
-            _marker: PhantomData<S>,
+        pub struct $name<const S: usize> {
             state: $module::State,
         }
 
-        impl<S: Size> Default for $name<S> {
+        impl<const S: usize> Default for $name<S> {
             fn default() -> Self {
                 let mut params = $module::Params::new();
-                params.hash_length(S::to_usize());
+                params.hash_length(S);
                 Self {
-                    _marker: PhantomData,
                     state: params.to_state(),
                 }
             }
         }
 
-        impl<S: Size> StatefulHasher for $name<S> {
-            type Size = S;
-            type Digest = $digest<Self::Size>;
+        impl<const S: usize> StatefulHasher<S> for $name<S> {
+            type Digest = $digest<S>;
 
             fn update(&mut self, input: &[u8]) {
                 self.state.update(input);
@@ -99,7 +99,9 @@ macro_rules! derive_hasher_blake {
 
             fn finalize(&self) -> Self::Digest {
                 let digest = self.state.finalize();
-                GenericArray::clone_from_slice(digest.as_bytes()).into()
+                let mut array = [0; S];
+                array.clone_from_slice(digest.as_bytes());
+                array.into()
             }
 
             fn reset(&mut self) {
@@ -115,63 +117,54 @@ macro_rules! derive_hasher_blake {
 #[cfg(feature = "blake2b")]
 pub mod blake2b {
     use super::*;
-    use core::marker::PhantomData;
-    use generic_array::typenum::{U32, U64};
 
     derive_hasher_blake!(blake2b_simd, Blake2bHasher, Blake2bDigest);
 
     /// 256 bit blake2b hasher.
-    pub type Blake2b256 = Blake2bHasher<U32>;
+    pub type Blake2b256 = Blake2bHasher<32>;
 
     /// 512 bit blake2b hasher.
-    pub type Blake2b512 = Blake2bHasher<U64>;
+    pub type Blake2b512 = Blake2bHasher<64>;
 }
 
 #[cfg(feature = "blake2s")]
 pub mod blake2s {
     use super::*;
-    use core::marker::PhantomData;
-    use generic_array::typenum::{U16, U32};
 
     derive_hasher_blake!(blake2s_simd, Blake2sHasher, Blake2sDigest);
 
     /// 256 bit blake2b hasher.
-    pub type Blake2s128 = Blake2sHasher<U16>;
+    pub type Blake2s128 = Blake2sHasher<16>;
 
     /// 512 bit blake2b hasher.
-    pub type Blake2s256 = Blake2sHasher<U32>;
+    pub type Blake2s256 = Blake2sHasher<32>;
 }
 
 #[cfg(feature = "blake3")]
 pub mod blake3 {
     use super::*;
-    use core::marker::PhantomData;
-    use generic_array::typenum::U32;
 
     // derive_hasher_blake!(blake3, Blake3Hasher, Blake3Digest);
     derive_digest!(Blake3Digest);
 
     /// Multihash hasher.
     #[derive(Debug)]
-    pub struct Blake3Hasher<S: Size> {
-        _marker: PhantomData<S>,
+    pub struct Blake3Hasher<const S: usize> {
         hasher: ::blake3::Hasher,
     }
 
-    impl<S: Size> Default for Blake3Hasher<S> {
+    impl<const S: usize> Default for Blake3Hasher<S> {
         fn default() -> Self {
             let hasher = ::blake3::Hasher::new();
 
             Self {
-                _marker: PhantomData,
                 hasher,
             }
         }
     }
 
-    impl<S: Size> StatefulHasher for Blake3Hasher<S> {
-        type Size = S;
-        type Digest = Blake3Digest<Self::Size>;
+    impl<const S: usize> StatefulHasher<S> for Blake3Hasher<S> {
+        type Digest = Blake3Digest<S>;
 
         fn update(&mut self, input: &[u8]) {
             self.hasher.update(input);
@@ -179,7 +172,9 @@ pub mod blake3 {
 
         fn finalize(&self) -> Self::Digest {
             let digest = self.hasher.finalize(); //default is 32 bytes anyway
-            GenericArray::clone_from_slice(digest.as_bytes()).into()
+            let mut array = [0; S];
+            array.clone_from_slice(digest.as_bytes());
+            array.into()
         }
 
         fn reset(&mut self) {
@@ -190,21 +185,20 @@ pub mod blake3 {
     derive_write!(Blake3Hasher);
 
     /// blake3-256 hasher.
-    pub type Blake3_256 = Blake3Hasher<U32>;
+    pub type Blake3_256 = Blake3Hasher<32>;
 }
 
 #[cfg(feature = "digest")]
 macro_rules! derive_hasher_sha {
-    ($module:ty, $name:ident, $size:ty, $digest:ident) => {
+    ($module:ty, $name:ident, $size:expr, $digest:ident) => {
         /// Multihash hasher.
         #[derive(Debug, Default)]
         pub struct $name {
             state: $module,
         }
 
-        impl $crate::hasher::StatefulHasher for $name {
-            type Size = $size;
-            type Digest = $digest<Self::Size>;
+        impl<const S: usize> $crate::hasher::StatefulHasher<S> for $name {
+            type Digest = $digest<S>;
 
             fn update(&mut self, input: &[u8]) {
                 use digest::Digest;
@@ -213,7 +207,11 @@ macro_rules! derive_hasher_sha {
 
             fn finalize(&self) -> Self::Digest {
                 use digest::Digest;
-                Self::Digest::from(self.state.clone().finalize())
+                // TODO: this extra array seems excessive to convert from a generic array
+                let a = self.state.clone().finalize().as_slice();
+                let array = [0; S];
+                array.copy_from_slice(a);
+                Self::Digest::from(array)
             }
 
             fn reset(&mut self) {
@@ -248,65 +246,68 @@ pub mod sha1 {
 #[cfg(feature = "sha2")]
 pub mod sha2 {
     use super::*;
-    use generic_array::typenum::{U32, U64};
 
     derive_digest!(Sha2Digest);
-    derive_hasher_sha!(sha_2::Sha256, Sha2_256, U32, Sha2Digest);
-    derive_hasher_sha!(sha_2::Sha512, Sha2_512, U64, Sha2Digest);
+    derive_hasher_sha!(sha_2::Sha256, Sha2_256, 32, Sha2Digest);
+    derive_hasher_sha!(sha_2::Sha512, Sha2_512, 64, Sha2Digest);
 }
 
 #[cfg(feature = "sha3")]
 pub mod sha3 {
     use super::*;
-    use generic_array::typenum::{U28, U32, U48, U64};
 
     derive_digest!(Sha3Digest);
-    derive_hasher_sha!(sha_3::Sha3_224, Sha3_224, U28, Sha3Digest);
-    derive_hasher_sha!(sha_3::Sha3_256, Sha3_256, U32, Sha3Digest);
-    derive_hasher_sha!(sha_3::Sha3_384, Sha3_384, U48, Sha3Digest);
-    derive_hasher_sha!(sha_3::Sha3_512, Sha3_512, U64, Sha3Digest);
+    derive_hasher_sha!(sha_3::Sha3_224, Sha3_224, 28, Sha3Digest);
+    derive_hasher_sha!(sha_3::Sha3_256, Sha3_256, 32, Sha3Digest);
+    derive_hasher_sha!(sha_3::Sha3_384, Sha3_384, 48, Sha3Digest);
+    derive_hasher_sha!(sha_3::Sha3_512, Sha3_512, 64, Sha3Digest);
 
     derive_digest!(KeccakDigest);
-    derive_hasher_sha!(sha_3::Keccak224, Keccak224, U28, KeccakDigest);
-    derive_hasher_sha!(sha_3::Keccak256, Keccak256, U32, KeccakDigest);
-    derive_hasher_sha!(sha_3::Keccak384, Keccak384, U48, KeccakDigest);
-    derive_hasher_sha!(sha_3::Keccak512, Keccak512, U64, KeccakDigest);
+    derive_hasher_sha!(sha_3::Keccak224, Keccak224, 28, KeccakDigest);
+    derive_hasher_sha!(sha_3::Keccak256, Keccak256, 32, KeccakDigest);
+    derive_hasher_sha!(sha_3::Keccak384, Keccak384, 48, KeccakDigest);
+    derive_hasher_sha!(sha_3::Keccak512, Keccak512, 64, KeccakDigest);
 }
 
 pub mod identity {
     use super::*;
     use crate::error::Error;
-    use generic_array::typenum::U32;
 
     /// Multihash digest.
-    #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-    pub struct IdentityDigest<S: Size>(u8, GenericArray<u8, S>);
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    pub struct IdentityDigest<const S: usize>(u8, [u8; S]);
 
-    impl<S: Size> AsRef<[u8]> for IdentityDigest<S> {
+    impl<const S: usize> Default for IdentityDigest<S> {
+        fn default() -> Self {
+            Self {0: 0, 1: [0u8; S]}
+        }
+    }
+
+    impl<const S: usize> AsRef<[u8]> for IdentityDigest<S> {
         fn as_ref(&self) -> &[u8] {
             &self.1[..self.0 as usize]
         }
     }
 
-    impl<S: Size> AsMut<[u8]> for IdentityDigest<S> {
+    impl<const S: usize> AsMut<[u8]> for IdentityDigest<S> {
         fn as_mut(&mut self) -> &mut [u8] {
             &mut self.1[..self.0 as usize]
         }
     }
 
-    impl<S: Size> From<GenericArray<u8, S>> for IdentityDigest<S> {
-        fn from(array: GenericArray<u8, S>) -> Self {
+    impl<const S: usize> From<[u8; S]> for IdentityDigest<S> {
+        fn from(array: [u8; S]) -> Self {
             Self(array.len() as u8, array)
         }
     }
 
-    impl<S: Size> From<IdentityDigest<S>> for GenericArray<u8, S> {
+    impl<const S: usize> From<IdentityDigest<S>> for [u8; S] {
         fn from(digest: IdentityDigest<S>) -> Self {
             digest.1
         }
     }
 
-    impl<S: Size> Digest<S> for IdentityDigest<S> {
+    impl<const S: usize> Digest<S> for IdentityDigest<S> {
         fn size(&self) -> u8 {
             self.0
         }
@@ -314,10 +315,10 @@ pub mod identity {
         // A custom implementation is needed as an identity hash value might be shorter than the
         // allocated Digest.
         fn wrap(digest: &[u8]) -> Result<Self, Error> {
-            if digest.len() > S::to_usize() {
+            if digest.len() > S {
                 return Err(Error::InvalidSize(digest.len() as _));
             }
-            let mut array = GenericArray::default();
+            let mut array = [0; S];
             let len = digest.len().min(array.len());
             array[..len].copy_from_slice(&digest[..len]);
             Ok(Self(len as u8, array))
@@ -333,10 +334,10 @@ pub mod identity {
             use unsigned_varint::io::read_u64;
 
             let size = read_u64(&mut r)?;
-            if size > S::to_u64() || size > u8::max_value() as u64 {
+            if size > S as u64|| size > u8::max_value() as u64 {
                 return Err(Error::InvalidSize(size));
             }
-            let mut digest = GenericArray::default();
+            let mut digest = [0; S];
             r.read_exact(&mut digest[..size as usize])?;
             Ok(Self(size as u8, digest))
         }
@@ -347,15 +348,21 @@ pub mod identity {
     /// # Panics
     ///
     /// Panics if the input is bigger than the maximum size.
-    #[derive(Debug, Default)]
-    pub struct IdentityHasher<S: Size> {
-        bytes: GenericArray<u8, S>,
+    #[derive(Debug)]
+    pub struct IdentityHasher<const S: usize> {
+        bytes: [u8; S],
         i: usize,
     }
 
-    impl<S: Size> StatefulHasher for IdentityHasher<S> {
-        type Size = S;
-        type Digest = IdentityDigest<Self::Size>;
+    impl<const S: usize> Default for IdentityHasher<S> {
+        fn default() -> Self {
+            Self {i: 0, bytes: [0u8; S]}
+        }
+    }
+
+
+    impl<const S: usize> StatefulHasher<S> for IdentityHasher<S> {
+        type Digest = IdentityDigest<S>;
 
         fn update(&mut self, input: &[u8]) {
             let start = self.i.min(self.bytes.len());
@@ -369,7 +376,7 @@ pub mod identity {
         }
 
         fn reset(&mut self) {
-            self.bytes = Default::default();
+            self.bytes = [0; S];
             self.i = 0;
         }
     }
@@ -381,7 +388,7 @@ pub mod identity {
     /// # Panics
     ///
     /// Panics if the input is bigger than 32 bytes.
-    pub type Identity256 = IdentityHasher<U32>;
+    pub type Identity256 = IdentityHasher<32>;
 }
 
 pub mod unknown {
@@ -399,13 +406,13 @@ pub mod strobe {
     derive_digest!(StrobeDigest);
 
     /// Strobe hasher.
-    pub struct StrobeHasher<S: Size> {
+    pub struct StrobeHasher<const S: usize> {
         _marker: PhantomData<S>,
         strobe: Strobe,
         initialized: bool,
     }
 
-    impl<S: Size> Default for StrobeHasher<S> {
+    impl<const S: usize> Default for StrobeHasher<S> {
         fn default() -> Self {
             Self {
                 _marker: PhantomData,
@@ -415,7 +422,7 @@ pub mod strobe {
         }
     }
 
-    impl<S: Size> StatefulHasher for StrobeHasher<S> {
+    impl<const S: usize> StatefulHasher for StrobeHasher<S> {
         type Size = S;
         type Digest = StrobeDigest<Self::Size>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,8 @@ mod multihash;
 mod multihash_impl;
 
 pub use crate::error::{Error, Result};
-pub use crate::hasher::{Digest, Hasher, Size, StatefulHasher};
+pub use crate::hasher::{Digest, Hasher, StatefulHasher};
 pub use crate::multihash::{Multihash as MultihashGeneric, MultihashDigest};
-pub use generic_array::typenum::{self, U128, U16, U20, U28, U32, U48, U64};
 #[cfg(feature = "derive")]
 pub use multihash_derive as derive;
 

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -7,15 +7,15 @@ use multihash_derive::Multihash;
 ///
 /// [`Multihash` derive]: crate::derive
 #[derive(Copy, Clone, Debug, Eq, Multihash, PartialEq)]
-#[mh(alloc_size = crate::U64)]
+#[mh(alloc_size = U64)]
 pub enum Code {
     /// SHA-256 (32-byte hash size)
     #[cfg(feature = "sha2")]
-    #[mh(code = 0x12, hasher = crate::Sha2_256, digest = crate::Sha2Digest<crate::U32>)]
+    #[mh(code = 0x12, hasher = crate::Sha2_256, digest = crate::Sha2Digest<32>)]
     Sha2_256,
     /// SHA-512 (64-byte hash size)
     #[cfg(feature = "sha2")]
-    #[mh(code = 0x13, hasher = crate::Sha2_512, digest = crate::Sha2Digest<crate::U64>)]
+    #[mh(code = 0x13, hasher = crate::Sha2_512, digest = crate::Sha2Digest<64>)]
     Sha2_512,
     /// SHA3-224 (28-byte hash size)
     #[cfg(feature = "sha3")]


### PR DESCRIPTION
What this PR does

- removes generic array
- implements Default for things that needed it by making an empty array `[0u8; SIZE]`

What it doesn't do:

- build
- modify proc macro
- fix SHA macro_rules! 
- some other things that need to be squashed to even build.