### PR TITLE
*: Remove parity-scale-codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ multihash-impl = ["derive"]
 derive = ["multihash-derive"]
 arb = ["quickcheck", "rand"]
 secure-hashes = ["blake2b", "blake2s", "blake3", "sha2", "sha3"]
-scale-codec = ["parity-scale-codec"]
 serde-codec = ["serde", "generic-array/serde"]
 
 blake2b = ["blake2b_simd"]
@@ -33,7 +32,6 @@ strobe = ["strobe-rs"]
 
 [dependencies]
 generic-array = "0.14.4"
-parity-scale-codec = { version = "1.3.5", optional = true, default-features = false, features = ["derive"] }
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.116", optional = true, default-features = false, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,13 +41,11 @@
 //! The `arb` feature flag enables the quickcheck arbitrary implementation for property based
 //! testing.
 //!
-//! For serializing the multihash there is support for [Serde] via the `serde-codec` feature and
-//! the [SCALE Codec] via the `scale-codec` feature.
+//! For serializing the multihash there is support for [Serde] via the `serde-codec` feature.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //! [`Multihash` derive]: crate::derive
 //! [Serde]: https://serde.rs
-//! [SCALE Codec]: https://github.com/paritytech/parity-scale-codec
 
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -179,66 +179,6 @@ impl<S: Size> From<Multihash<S>> for Vec<u8> {
     }
 }
 
-#[cfg(feature = "scale-codec")]
-impl parity_scale_codec::Encode for Multihash<crate::U32> {
-    fn encode_to<EncOut: parity_scale_codec::Output>(&self, dest: &mut EncOut) {
-        let mut digest = [0; 32];
-        digest.copy_from_slice(&self.digest);
-        dest.push(&self.code);
-        dest.push(&self.size);
-        dest.push(&digest);
-    }
-}
-
-#[cfg(feature = "scale-codec")]
-impl parity_scale_codec::EncodeLike for Multihash<crate::U32> {}
-
-#[cfg(feature = "scale-codec")]
-impl parity_scale_codec::Decode for Multihash<crate::U32> {
-    fn decode<DecIn: parity_scale_codec::Input>(
-        input: &mut DecIn,
-    ) -> Result<Self, parity_scale_codec::Error> {
-        Ok(Multihash {
-            code: parity_scale_codec::Decode::decode(input)?,
-            size: parity_scale_codec::Decode::decode(input)?,
-            digest: {
-                let digest = <[u8; 32]>::decode(input)?;
-                GenericArray::clone_from_slice(&digest)
-            },
-        })
-    }
-}
-
-#[cfg(feature = "scale-codec")]
-impl parity_scale_codec::Encode for Multihash<crate::U64> {
-    fn encode_to<EncOut: parity_scale_codec::Output>(&self, dest: &mut EncOut) {
-        let mut digest = [0; 64];
-        digest.copy_from_slice(&self.digest);
-        dest.push(&self.code);
-        dest.push(&self.size);
-        dest.push(&digest);
-    }
-}
-
-#[cfg(feature = "scale-codec")]
-impl parity_scale_codec::EncodeLike for Multihash<crate::U64> {}
-
-#[cfg(feature = "scale-codec")]
-impl parity_scale_codec::Decode for Multihash<crate::U64> {
-    fn decode<DecIn: parity_scale_codec::Input>(
-        input: &mut DecIn,
-    ) -> Result<Self, parity_scale_codec::Error> {
-        Ok(Multihash {
-            code: parity_scale_codec::Decode::decode(input)?,
-            size: parity_scale_codec::Decode::decode(input)?,
-            digest: {
-                let digest = <[u8; 64]>::decode(input)?;
-                GenericArray::clone_from_slice(&digest)
-            },
-        })
-    }
-}
-
 /// Writes the multihash to a byte stream.
 #[cfg(feature = "std")]
 pub fn write_multihash<W>(mut w: W, code: u64, size: u8, digest: &[u8]) -> Result<(), Error>
@@ -297,17 +237,6 @@ mod tests {
         hash.write(&mut buf[..]).unwrap();
         let hash2 = Multihash::read(&buf[..]).unwrap();
         assert_eq!(hash, hash2);
-    }
-
-    #[test]
-    #[cfg(feature = "scale-codec")]
-    fn test_scale() {
-        use parity_scale_codec::{Decode, Encode};
-
-        let mh = Multihash::<crate::U32>::default();
-        let bytes = mh.encode();
-        let mh2: Multihash<crate::U32> = Decode::decode(&mut &bytes[..]).unwrap();
-        assert_eq!(mh, mh2);
     }
 
     #[test]


### PR DESCRIPTION
Given that there are no known users of the scale encoding feature, this
commit removes it, making overall maintenance easier.

For more details see:
https://github.com/multiformats/rust-multihash/pull/118