### PR TITLE
WIP: allow read/write without std

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,5 +51,11 @@ impl From<ReadError> for Error {
     }
 }
 
+impl From<DecodeError> for Error {
+    fn from(err: DecodeError) -> Self {
+        Self::Varint(err)
+    }
+}
+
 /// Multihash result.
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
Unfortunately, there is no core::io. So this implementation works by duplicating several functions and implementing them for slices.