### PR TITLE
Fix scale-codec for `Multihash`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[cfg(any(test, feature = "arb"))]
 mod arb;
 mod error;


### PR DESCRIPTION
~~waiting for #139 to be merged firstly~~

This PR is a breaking change.

**BREAKING CHANGE**: Write the digest of multihash directly to dest when encoding multihash, since we have known the size of digest.
    
We do not choose to encode &[u8] directly, because it will add extra bytes
(the compact length of digest) at the beinging of encoding result.
For a valid multihash, the length of digest must equal to `size` field of multihash.
Therefore, we can only read raw bytes whose length is equal to `size` when decoding.
    
And the digest of Multihash\<U64\> is of type [u8; 64], taking Code::Sha2_256 as an example,
if the digest is treated as &[u8] when encoding, useless data will be added to
the encoding result.