### PR TITLE
fix: use new feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/multihash/"
 edition = "2018"
+resolver = "2"
 
 [features]
 default = ["std", "derive", "multihash-impl", "secure-hashes"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Proc macro for deriving custom multihash tables."
 license = "MIT"
 repository = "https://github.com/multiformats/multihash"
+resolver = "2"
 
 [lib]
 proc-macro = true
@@ -24,4 +25,4 @@ std = []
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
-multihash = { path = "..", default-features = false }
+multihash = { path = "..", default-features = false, features = ["derive", "sha2"] }


### PR DESCRIPTION
This lets us have additional features in the dev dependencies that aren't used in the non-dev dependencies. Without this, no_std will stop working if start depending on memchr.