### PR TITLE
Enable cargo test without command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "criterion",
  "digest",
  "hex",
+ "multihash",
  "multihash-derive",
  "parity-scale-codec",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 [features]
 default = ["std", "derive", "multihash-impl", "secure-hashes"]
 std = ["unsigned-varint/std", "multihash-derive/std", "alloc"]
-alloc = []
+alloc = ["core2/alloc"]
 multihash-impl = ["derive"]
 derive = ["multihash-derive"]
 arb = ["quickcheck", "rand"]
@@ -51,12 +51,15 @@ sha-2 = { version = "0.9.0", default-features = false, optional = true, package 
 sha-3 = { version = "0.9.0", default-features = false, optional = true, package = "sha3" }
 strobe-rs = { version = "0.6.2", default-features = false, optional = true }
 
-core2 = { version = "0.3", default-features = false, features = ["alloc"] }
+core2 = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"
 hex = "0.4.2"
 serde_json = "1.0.58"
+quickcheck = "0.9.2"
+rand = "0.7.3"
+multihash = { path = ".", features = ["sha1", "strobe"] }
 
 [[bench]]
 name = "multihash"


### PR DESCRIPTION
Also makes core2 alloc feature optional