### PR TITLE
fix: remove the "identity" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde-codec = ["serde", "serde-big-array"]
 
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]
-identity = []
 sha1 = ["digest", "sha-1"]
 sha2 = ["digest", "sha-2"]
 sha3 = ["digest", "sha-3"]

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -71,12 +71,6 @@ pub enum Code {
     #[cfg(feature = "blake3")]
     #[mh(code = 0x1e, hasher = crate::Blake3_256)]
     Blake3_256,
-
-    // The following hashes are not cryptographically secure hashes and are not enabled by default
-    /// Identity hash (max. 64 bytes)
-    #[cfg(feature = "identity")]
-    #[mh(code = 0x00, hasher = crate::IdentityHasher::<64>)]
-    Identity,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There are _always_ safer ways to compute an identity hash, and this feature can cause otherwise "safe" code to crash. With this feature enabled, `Code::try_from(codec)?.digest(input)` would crash if `codec` was 0 and `input` was more than 64 bytes.

Unfortunately, this was a cargo "feature" so a single dependency enabling it means it's enabled for all other crates in the build.

Users of this code migrate to `Multihash::wrap(0, digest)`, which returns an error if the digest is too large instead of panicing.

fixes #194