### PR TITLE
Add Arbitrary implementation used for fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +474,7 @@ dependencies = [
 name = "multihash"
 version = "0.16.1"
 dependencies = [
+ "arbitrary",
  "blake2b_simd",
  "blake2s_simd",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ std = ["unsigned-varint/std", "multihash-derive/std", "alloc"]
 alloc = ["core2/alloc"]
 multihash-impl = ["derive"]
 derive = ["multihash-derive"]
-arb = ["quickcheck", "rand"]
+arb = ["quickcheck", "rand", "arbitrary"]
 secure-hashes = ["blake2b", "blake2s", "blake3", "sha2", "sha3"]
 scale-codec = ["parity-scale-codec"]
 serde-codec = ["serde", "serde-big-array"]
@@ -41,6 +41,7 @@ serde = { version = "1.0.116", optional = true, default-features = false, featur
 serde-big-array = { version = "0.3.2", optional = true, features = ["const-generics"] }
 multihash-derive = { version = "0.8.0", path = "derive", default-features = false, optional = true }
 unsigned-varint = { version = "0.7.1", default-features = false }
+arbitrary = {version = "1.1.0", optional = true }
 
 blake2b_simd = { version = "1.0.0", default-features = false, optional = true }
 blake2s_simd = { version = "1.0.0", default-features = false, optional = true }
@@ -59,6 +60,7 @@ hex = "0.4.2"
 serde_json = "1.0.58"
 quickcheck = "0.9.2"
 rand = "0.7.3"
+arbitrary = "1.1.0"
 multihash = { path = ".", features = ["sha1", "strobe"] }
 
 [[bench]]

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,13 +1,15 @@
-use quickcheck::{Arbitrary, Gen};
+use quickcheck::Gen;
 use rand::{
     distributions::{weighted::WeightedIndex, Distribution},
     Rng,
 };
 
+use arbitrary::{size_hint, Unstructured};
+
 use crate::MultihashGeneric;
 
 /// Generates a random valid multihash.
-impl<const S: usize> Arbitrary for MultihashGeneric<S> {
+impl<const S: usize> quickcheck::Arbitrary for MultihashGeneric<S> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         // In real world lower multihash codes are more likely to happen, hence distribute them
         // with bias towards smaller values.
@@ -30,5 +32,50 @@ impl<const S: usize> Arbitrary for MultihashGeneric<S> {
         let mut data = [0; S];
         g.fill_bytes(&mut data);
         MultihashGeneric::wrap(code, &data[..size]).unwrap()
+    }
+}
+
+impl<'a, const S: usize> arbitrary::Arbitrary<'a> for MultihashGeneric<S> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut code = 0u64;
+        for x in u.arbitrary_iter::<u8>()? {
+            // arbitrary_iter gives next item with probability 1/2
+            let next = code
+                .checked_shl(7)
+                .zip(x.ok())
+                .map(|(next, x)| next.saturating_add((x & 0x7F) as u64));
+
+            match next {
+                None => break,
+                Some(next) => code = next,
+            }
+        }
+
+        let size = u.int_in_range(0..=S)?;
+        let data = u.bytes(size)?;
+
+        Ok(MultihashGeneric::wrap(code, data).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::and(<[usize; 2]>::size_hint(depth), (0, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::MultihashGeneric;
+    use arbitrary::{Arbitrary, Unstructured};
+
+    #[test]
+    fn arbitrary() {
+        let mut u = Unstructured::new(&[
+            1, 2, 4, 13, 5, 6, 7, 8, 9, 6, 10, 243, 43, 231, 123, 43, 153,
+        ]);
+        let mh = <MultihashGeneric<16> as Arbitrary>::arbitrary(&mut u).unwrap();
+        let mh2 =
+            MultihashGeneric::<16>::wrap(2, &[5, 6, 7, 8, 9, 6, 10, 243, 43, 231, 123, 43, 153])
+                .unwrap();
+        assert_eq!(mh, mh2);
     }
 }


### PR DESCRIPTION
arbitrary::Arbitrary is a trait used for generation of arbitrary values
of structs used for fuzzing.

It differes from the quickcheck::Arbitrary by sourcing from a buffer
instead of Rng.