### PR TITLE
Remove Identity hash from table, add helper function and examples of alternatives 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,12 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "bytes"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,7 +479,6 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
- "bytes",
  "core2",
  "criterion",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +485,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
+ "bytes",
  "core2",
  "criterion",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ quickcheck = "0.9.2"
 rand = "0.7.3"
 arbitrary = "1.1.0"
 multihash = { path = ".", features = ["sha1", "strobe"] }
-bytes = "1.1.0"
 
 [[bench]]
 name = "multihash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ quickcheck = "0.9.2"
 rand = "0.7.3"
 arbitrary = "1.1.0"
 multihash = { path = ".", features = ["sha1", "strobe"] }
+bytes = "1.1.0"
 
 [[bench]]
 name = "multihash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde-codec = ["serde", "serde-big-array"]
 
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]
+# identity feature is depricated
 identity = []
 sha1 = ["digest", "sha-1"]
 sha2 = ["digest", "sha-2"]

--- a/examples/identity_hasher.rs
+++ b/examples/identity_hasher.rs
@@ -44,16 +44,19 @@ pub enum Code {
     Sha2_256,
 }
 
-#[allow(unused)]
 fn main() {
     // overwrite and trunk with code
 
     let src = b"hello world!";
     let ident_trunk = Code::IdentityTrunk.digest(src);
 
+    assert_eq!(ident_trunk.digest(), src);
+
     // input bigger than default table, but still const sized
     let big_src = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula tempor magna quis egestas. Etiam quis rhoncus neque.";
-
+    
+    let truncated = Code::IdentityTrunk.digest(big_src);
+    assert_eq!(truncated.digest(), &big_src[..64]);
     //
     // Helper functions cannot be used with normal table if S != alloc_size, fancier const trait bounds in the future may allow for interop where S <= alloc_size
     //
@@ -73,5 +76,8 @@ fn main() {
 
     // makes use of the const sized input to infer the output size
     let big_arr_mh = identity_hash_arr(big_src);
+    assert_eq!(big_arr_mh.digest(), big_src);
+    // size must be specified
     let big_mh = identity_hash::<128>(big_src);
+    assert_eq!(big_mh.digest(), big_src);
 }

--- a/examples/identity_hasher.rs
+++ b/examples/identity_hasher.rs
@@ -1,5 +1,3 @@
-use bytes::{Buf, Bytes};
-
 use multihash::derive::Multihash;
 use multihash::{Error, Hasher, MultihashDigest, MultihashGeneric, Sha2_256};
 
@@ -37,49 +35,11 @@ impl<const S: usize> Hasher for IdentityTrunk<S> {
     }
 }
 
-/// Borrows and concats slices using Bytes crate
-#[derive(Debug, Default)]
-pub struct IdentityBorrow(Bytes);
-
-impl Hasher for IdentityBorrow {
-    fn update(&mut self, input: &[u8]) {
-        let new = (*self.0).chain(input);
-        self.0 = Bytes::copy_from_slice(new.chunk());
-    }
-    fn finalize(&mut self) -> &[u8] {
-        &self.0
-    }
-    fn reset(&mut self) {
-        *self = Self::default();
-    }
-}
-
-/// update allocates & appends, Alloc only
-#[derive(Default, Debug)]
-pub struct IdentityAlloc(Vec<u8>);
-
-impl Hasher for IdentityAlloc {
-    fn update(&mut self, input: &[u8]) {
-        self.0.extend(input);
-    }
-    fn finalize(&mut self) -> &[u8] {
-        &self.0
-    }
-    fn reset(&mut self) {
-        self.0.clear();
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
 #[mh(alloc_size = 64)]
 pub enum Code {
     #[mh(code = 0x00, hasher = IdentityTrunk::<64>)]
     IdentityTrunk,
-    // These will panic and if input > alloc_size, use alternate methods if you want to use bigger than alocated size
-    // #[mh(code = 0x02, hasher = IdentityBorrow)]
-    // IdentityBorrow,
-    // #[mh(code = 0x03, hasher = IdentityAlloc)]
-    // IdentityAlloc,
     #[mh(code = 0x12, hasher = Sha2_256)]
     Sha2_256,
 }
@@ -90,14 +50,15 @@ fn main() {
     let src = b"hello world!";
     let ident_trunk = Code::IdentityTrunk.digest(src);
 
-    // for bigger than default table, but still known smaller than a const
-
+    // input bigger than default table, but still const sized
     let big_src = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula tempor magna quis egestas. Etiam quis rhoncus neque.";
 
+    //
     // Helper functions cannot be used with normal table if S != alloc_size, fancier const trait bounds in the future may allow for interop where S <= alloc_size
+    //
 
     pub const IDENTITY_CODE: u64 = 0x0;
-    // input must be const sized for this
+    // blind copy of the input array
     pub fn identity_hash_arr<const S: usize>(input: &[u8; S]) -> MultihashGeneric<S> {
         MultihashGeneric::wrap(IDENTITY_CODE, input).unwrap()
     }
@@ -109,6 +70,7 @@ fn main() {
         MultihashGeneric::wrap(IDENTITY_CODE, hasher.finalize()).unwrap()
     }
 
+    // makes use of the const sized input to infer the output size
     let big_arr_mh = identity_hash_arr(big_src);
     let big_mh = identity_hash::<128>(big_src);
 }

--- a/examples/identity_hasher.rs
+++ b/examples/identity_hasher.rs
@@ -1,7 +1,7 @@
 use multihash::derive::Multihash;
 use multihash::{Error, Hasher, MultihashDigest, MultihashGeneric, Sha2_256};
 
-/// update appends and truncates/ignores updates > S
+/// update appends to end of buffer but truncates/ignores bytes after len > S
 #[derive(Debug)]
 pub struct IdentityTrunk<const S: usize> {
     cursor: usize,
@@ -44,6 +44,7 @@ pub enum Code {
     Sha2_256,
 }
 
+#[allow(unused)]
 fn main() {
     // overwrite and trunk with code
 

--- a/examples/identity_hasher.rs
+++ b/examples/identity_hasher.rs
@@ -1,0 +1,114 @@
+use bytes::{Buf, Bytes};
+
+use multihash::derive::Multihash;
+use multihash::{Error, Hasher, MultihashDigest, MultihashGeneric, Sha2_256};
+
+/// update appends and truncates/ignores updates > S
+#[derive(Debug)]
+pub struct IdentityTrunk<const S: usize> {
+    cursor: usize,
+    arr: [u8; S],
+}
+
+impl<const S: usize> Default for IdentityTrunk<S> {
+    fn default() -> Self {
+        Self {
+            cursor: 0,
+            arr: [0u8; S],
+        }
+    }
+}
+impl<const S: usize> Hasher for IdentityTrunk<S> {
+    fn update(&mut self, input: &[u8]) {
+        let src_end = (self.cursor + input.len()).min(self.arr.len());
+        let input_end = input.len().min(self.arr.len() - self.cursor);
+
+        self.arr[self.cursor..src_end].copy_from_slice(&input[..input_end]);
+        self.cursor = src_end;
+    }
+    fn finalize(&mut self) -> &[u8] {
+        &self.arr[..self.cursor]
+    }
+    fn reset(&mut self) {
+        *self = Self {
+            cursor: 0,
+            arr: [0u8; S],
+        };
+    }
+}
+
+/// Borrows and concats slices using Bytes crate
+#[derive(Debug, Default)]
+pub struct IdentityBorrow(Bytes);
+
+impl Hasher for IdentityBorrow {
+    fn update(&mut self, input: &[u8]) {
+        let new = (*self.0).chain(input);
+        self.0 = Bytes::copy_from_slice(new.chunk());
+    }
+    fn finalize(&mut self) -> &[u8] {
+        &self.0
+    }
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// update allocates & appends, Alloc only
+#[derive(Default, Debug)]
+pub struct IdentityAlloc(Vec<u8>);
+
+impl Hasher for IdentityAlloc {
+    fn update(&mut self, input: &[u8]) {
+        self.0.extend(input);
+    }
+    fn finalize(&mut self) -> &[u8] {
+        &self.0
+    }
+    fn reset(&mut self) {
+        self.0.clear();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[mh(alloc_size = 64)]
+pub enum Code {
+    #[mh(code = 0x00, hasher = IdentityTrunk::<64>)]
+    IdentityTrunk,
+    // These will panic and if input > alloc_size, use alternate methods if you want to use bigger than alocated size
+    // #[mh(code = 0x02, hasher = IdentityBorrow)]
+    // IdentityBorrow,
+    // #[mh(code = 0x03, hasher = IdentityAlloc)]
+    // IdentityAlloc,
+    #[mh(code = 0x12, hasher = Sha2_256)]
+    Sha2_256,
+}
+
+fn main() {
+    // overwrite and trunk with code
+
+    let src = b"hello world!";
+    let ident_trunk = Code::IdentityTrunk.digest(src);
+
+    // for bigger than default table, but still known smaller than a const
+
+    let big_src = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula tempor magna quis egestas. Etiam quis rhoncus neque.";
+
+    // Helper functions cannot be used with normal table if S != alloc_size, fancier const trait bounds in the future may allow for interop where S <= alloc_size
+
+    pub const IDENTITY_CODE: u64 = 0x0;
+    // input must be const sized for this
+    pub fn identity_hash_arr<const S: usize>(input: &[u8; S]) -> MultihashGeneric<S> {
+        MultihashGeneric::wrap(IDENTITY_CODE, input).unwrap()
+    }
+
+    // input is truncated to S size
+    pub fn identity_hash<const S: usize>(input: &[u8]) -> MultihashGeneric<S> {
+        let mut hasher = IdentityTrunk::<S>::default();
+        hasher.update(input);
+        MultihashGeneric::wrap(IDENTITY_CODE, hasher.finalize()).unwrap()
+    }
+
+    let big_arr_mh = identity_hash_arr(big_src);
+    let big_mh = identity_hash::<128>(big_src);
+}

--- a/examples/identity_hasher.rs
+++ b/examples/identity_hasher.rs
@@ -54,7 +54,7 @@ fn main() {
 
     // input bigger than default table, but still const sized
     let big_src = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus vehicula tempor magna quis egestas. Etiam quis rhoncus neque.";
-    
+
     let truncated = Code::IdentityTrunk.digest(big_src);
     assert_eq!(truncated.digest(), &big_src[..64]);
     //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,11 @@
 //!
 //!  - `blake2b`: (default) Enable Blake2b hashers
 //!  - `blake2s`: (default) Enable Blake2s hashers
-//!  - `identity`: Enable the Identity hashers (using it is discouraged as it's not a hash function
-//!     in the sense that it produces a fixed sized output independent of the input size)
 //!  - `sha1`: Enable SHA-1 hasher
 //!  - `sha2`: (default) Enable SHA-2 hashers
 //!  - `sha3`: (default) Enable SHA-3 hashers
 //!  - `strobe`: Enable Strobe hashers
+//!  - `identity`: A depricated feature for identity hashes.
 //!
 //! In order to enable all cryptographically secure hashers, you can set the `secure-hashes`
 //! feature flag (enabled by default).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,3 +92,13 @@ pub use crate::hasher_impl::sha3::{Keccak224, Keccak256, Keccak384, Keccak512};
 pub use crate::hasher_impl::sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 #[cfg(feature = "strobe")]
 pub use crate::hasher_impl::strobe::{Strobe256, Strobe512, StrobeHasher};
+
+/// Code reserved for Identity "hash"
+pub const IDENTITY_CODE: u64 = 0x0;
+/// Helper for generating Identity hashes (context https://github.com/multiformats/rust-multihash/pull/196).
+/// Will error if `data.len() > S`
+/// 
+/// See examples for a few other approaches if this doesn't fit your application
+pub fn identity_hash<const S: usize>(data: impl AsRef<[u8]>) -> Result<MultihashGeneric<S>> {
+    MultihashGeneric::wrap(IDENTITY_CODE, data.as_ref())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub use crate::hasher_impl::strobe::{Strobe256, Strobe512, StrobeHasher};
 pub const IDENTITY_CODE: u64 = 0x0;
 /// Helper for generating Identity hashes (context https://github.com/multiformats/rust-multihash/pull/196).
 /// Will error if `data.len() > S`
-/// 
+///
 /// See examples for a few other approaches if this doesn't fit your application
 pub fn identity_hash<const S: usize>(data: impl AsRef<[u8]>) -> Result<MultihashGeneric<S>> {
     MultihashGeneric::wrap(IDENTITY_CODE, data.as_ref())

--- a/src/multihash_impl.rs
+++ b/src/multihash_impl.rs
@@ -83,12 +83,6 @@ pub enum Code {
     #[cfg(feature = "ripemd")]
     #[mh(code = 0x1055, hasher = crate::Ripemd320)]
     Ripemd320,
-
-    // The following hashes are not cryptographically secure hashes and are not enabled by default
-    /// Identity hash (max. 64 bytes)
-    #[cfg(feature = "identity")]
-    #[mh(code = 0x00, hasher = crate::IdentityHasher::<64>)]
-    Identity,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
related to #196 

closes #194

In order to allow for easier transition for downstream users, this adds a few ideas how to implement the identity hasher.

Undecided yet is about what to do with non-const sized identity hashers. Some users may be ok with allocating in order to have larger identity hashes. This is a fairly far edge-case which can be covered, but is debatable whether it should actually be actively supported by us.
(update): We won't be supporting alloc-dependent hashes in this crate for now unless significant desire exists to add them.

~~Another thing introduced is the `bytes` crate which can do fun zero-copy things. This part was mostly for me to become more familiar with the crate.~~