### PR TITLE
revert: Revert "skip fmt on stable"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable, nightly]
+        toolchain: [stable]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -31,7 +31,6 @@ jobs:
           components: rustfmt, clippy
 
       - name: Check Code Format
-        if: ${{ matrix.toolchain == 'nightly' }}
         uses: actions-rs/cargo@v1
         with:
           command: fmt


### PR DESCRIPTION
`cargo fmt` fmt prints warnings, but doesn't lead to failures.

This reverts commit 6235d260e7e95a51fdf697940fda0b02eb9e9434.