### PR TITLE
chore: add v0.18 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# [v0.18.0](https://github.com/multiformats/rust-multihash/compare/v0.17.0...v) (2022-12-06)
+
+
+### Bug Fixes
+
+* remove Nix support ([#254](https://github.com/multiformats/rust-multihash/issues/254)) ([ebf57dd](https://github.com/multiformats/rust-multihash/commit/ebf57ddb82be2d2fd0a2f00666b0f888d4c78e1b)), closes [#247](https://github.com/multiformats/rust-multihash/issues/247)
+* update to Rust edition 2021 ([#255](https://github.com/multiformats/rust-multihash/issues/255)) ([da53376](https://github.com/multiformats/rust-multihash/commit/da53376e0d9cf2d82d6c0d10590a77991cb3a6b6))
+
+
+### Features
+
+* add `encoded_len` and bytes written ([#252](https://github.com/multiformats/rust-multihash/issues/252)) ([b3cc43e](https://github.com/multiformats/rust-multihash/commit/b3cc43ecb6f9c59da774b094853d6542430d55ad))
+
+
+### BREAKING CHANGES
+
+* update to Rust edition 2021
+* `Multihash::write()` returns bytes written
+
+    Prior to this change it returned an empty tuple `()`, now it returns
+the bytes written.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+Release process
+===============
+
+Generating Changelog
+--------------------
+
+Install dependencies
+
+```sh
+$ npm install -g conventional-changelog-cli
+$ cd rust-multihash
+$ conventional-changelog --preset angular
+```
+
+Add the output of that to `CHANGELOG.md`, and write a human-centric summary of changes.
+Update the linked output to reference the new version, which conventional-changelog doesn't know about:
+
+```md
+# [](https://github.com/multiformats/rust-multihash/compare/v0.17.0...v) (2022-12-06)
+```
+becomes:
+```md
+# [v0.18.0](https://github.com/multiformats/rust-multihash/compare/v0.17.0...v0.18.0) (2022-12-06)
+```
+
+## Publishing
+
+Publishing on crates.io, bumping version & generating tags is done using [`cargo-release`](https://github.com/crate-ci/cargo-release).
+
+This requires the following permissions 
+
+- on github.com/multiformats/rust-multihash
+  - creating tags 
+  - pushing to `main`
+- on crates.io
+  - publish access to all published crates
+
+Dry run
+
+```sh
+$ cargo release <patch|minor|major>
+```
+
+Actual publishing
+
+```sh
+$ cargo release --execute <patch|minor|major>
+```


### PR DESCRIPTION
This commit prepares a new release. It also documents the release process. Thanks iroh team for letting me copy the process.

I plan to do a 0.18 release tomorrow. Please raise any objections if you have any.