### PR TITLE
fix: update to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ authors = ["dignifiedquire <dignifiedquire@gmail.com>", "David Craven <david@cra
 license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/multihash/"
-edition = "2018"
-resolver = "2"
+edition = "2021"
+rust-version = "1.59"
 
 [features]
 default = ["std", "derive", "multihash-impl", "secure-hashes"]


### PR DESCRIPTION
The crate was already using resolver v2, hence it makes sense to upgrade to Rust edition 2021, which implicitly uses that resolver.

Also set the minimum required Rust version to 1.59 due to the `constant_time_eq` dependency.

BREAKING CHANGE: update to Rust edition 2021

---

I thought as we do a breaking release, we might as well upgrade the rust edition.