### PR TITLE
Two small cleanups before the release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
+Cargo.lock
 *.bk
 .idea

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,11 +27,11 @@ becomes:
 
 Publishing on crates.io, bumping version & generating tags is done using [`cargo-release`](https://github.com/crate-ci/cargo-release).
 
-This requires the following permissions 
+This requires the following permissions
 
 - on github.com/multiformats/rust-multihash
-  - creating tags 
-  - pushing to `main`
+  - creating tags
+  - pushing to `master`
 - on crates.io
   - publish access to all published crates
 


### PR DESCRIPTION
Those are just minor things that don't even need a changelog entry. Last changes before doing the 0.18 release.