### PR TITLE
feat(multihash): update MSRV to 1.60.0 and use new syntax for cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,19 @@
 [workspace]
 members = ["derive", "."]
+resolver = "2"
 
 [package]
 name = "multihash"
-description = "Implementation of the multihash format"
-repository = "https://github.com/multiformats/rust-multihash"
-keywords = ["multihash", "ipfs"]
 version = "0.18.0"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "David Craven <david@craven.ch>", "Volker Mische <volker.mische@gmail.com>"]
+edition = "2021"
+rust-version = "1.60"
+description = "Implementation of the multihash format"
 license = "MIT"
 readme = "README.md"
+keywords = ["multihash", "ipfs"]
+repository = "https://github.com/multiformats/rust-multihash"
 documentation = "https://docs.rs/multihash/"
-edition = "2021"
-rust-version = "1.59"
 
 [features]
 default = ["std", "derive", "multihash-impl", "secure-hashes"]
@@ -21,49 +22,53 @@ alloc = ["core2/alloc"]
 multihash-impl = ["derive"]
 derive = ["multihash-derive"]
 arb = ["quickcheck", "rand", "arbitrary"]
-secure-hashes = ["blake2b", "blake2s", "blake3", "sha2", "sha3"]
 scale-codec = ["parity-scale-codec"]
 serde-codec = ["serde", "serde-big-array"]
-
+secure-hashes = ["blake2b", "blake2s", "blake3", "sha2", "sha3"]
 blake2b = ["blake2b_simd"]
 blake2s = ["blake2s_simd"]
+blake3 = ["dep:blake3"]
 identity = []
-sha1 = ["digest", "sha-1"]
-sha2 = ["digest", "sha-2"]
-sha3 = ["digest", "sha-3"]
+sha1 = ["digest", "dep:sha1"]
+sha2 = ["digest", "dep:sha2"]
+sha3 = ["digest", "dep:sha3"]
+ripemd = ["digest", "dep:ripemd"]
 strobe = ["strobe-rs"]
-ripemd = ["ripemd-rs"]
 
 [dependencies]
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
-quickcheck = { version = "1.0.3", optional = true }
-rand = { version = "0.8.5", optional = true, features = ["small_rng"] }
-serde = { version = "1.0.116", optional = true, default-features = false, features = ["derive"] }
-serde-big-array = { version = "0.3.2", optional = true, features = ["const-generics"] }
+core2 = { version = "0.4.0", default-features = false }
 multihash-derive = { version = "0.8.0", path = "derive", default-features = false, optional = true }
 unsigned-varint = { version = "0.7.1", default-features = false }
-arbitrary = {version = "1.1.0", optional = true }
 
+# Optional arbitrary features.
+arbitrary = { version = "1.1.0", optional = true }
+quickcheck = { version = "1.0.3", optional = true }
+rand = { version = "0.8.5", features = ["small_rng"], optional = true }
+
+# Optional codec features
+parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0.116", default-features = false, features = ["derive"], optional = true }
+serde-big-array = { version = "0.4.1", optional = true }
+
+# Optional hash algorithms
 blake2b_simd = { version = "1.0.0", default-features = false, optional = true }
 blake2s_simd = { version = "1.0.0", default-features = false, optional = true }
 blake3 = { version = "1.2.0", default-features = false, optional = true }
 digest = { version = "0.10.1", default-features = false, optional = true }
-sha-1 = { version = "0.10.0", default-features = false, optional = true }
-sha-2 = { version = "0.10.0", default-features = false, optional = true, package = "sha2" }
-sha-3 = { version = "0.10.0", default-features = false, optional = true, package = "sha3" }
-strobe-rs = { version = "0.7.0", default-features = false, optional = true }
-ripemd-rs = { package = "ripemd", version = "0.1.1", optional = true}
-
-core2 = { version = "0.4.0", default-features = false }
+ripemd = { version = "0.1.1", optional = true }
+sha1 = { version = "0.10.0", default-features = false, optional = true }
+sha2 = { version = "0.10.0", default-features = false, optional = true }
+sha3 = { version = "0.10.0", default-features = false, optional = true }
+strobe-rs = { version = "0.8.1", default-features = false, optional = true }
 
 [dev-dependencies]
-criterion = "0.3.3"
+arbitrary = "1.1.0"
+criterion = "0.4.0"
 hex = "0.4.2"
-serde_json = "1.0.58"
+multihash = { path = ".", features = ["sha1", "strobe"] }
 quickcheck = "1.0.3"
 rand = "0.8.5"
-arbitrary = "1.1.0"
-multihash = { path = ".", features = ["sha1", "strobe"] }
+serde_json = "1.0.58"
 
 [[bench]]
 name = "multihash"

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ multihash = "*"
 
 Then run `cargo build`.
 
-MSRV 1.51.0 due to use of const generics
-
 ## Usage
 
 ```rust

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,19 +2,19 @@
 name = "multihash-derive"
 version = "0.8.1"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.60"
 description = "Proc macro for deriving custom multihash tables."
 license = "MIT"
 repository = "https://github.com/multiformats/multihash"
-resolver = "2"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { version = "1.0.24", features = ["span-locations"] }
 proc-macro-crate = "~1.1.0"
 proc-macro-error = "1.0.4"
+proc-macro2 = { version = "1.0.24", features = ["span-locations"] }
 quote = "1.0.7"
 syn = "1.0.42"
 synstructure = "0.12.4"
@@ -24,5 +24,5 @@ default = ["std"]
 std = []
 
 [dev-dependencies]
-pretty_assertions = "1.0.0"
 multihash = { path = "..", default-features = false, features = ["derive", "sha2"] }
+pretty_assertions = "1.0.0"

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,6 +1,6 @@
 use quickcheck::Gen;
 use rand::{
-    distributions::{weighted::WeightedIndex, Distribution},
+    distributions::{Distribution, WeightedIndex},
     Rng, RngCore, SeedableRng,
 };
 

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -207,28 +207,27 @@ pub mod sha1 {
 pub mod sha2 {
     use super::*;
 
-    derive_rustcrypto_hasher!(sha_2::Sha256, Sha2_256, 32);
-    derive_rustcrypto_hasher!(sha_2::Sha512, Sha2_512, 64);
+    derive_rustcrypto_hasher!(::sha2::Sha256, Sha2_256, 32);
+    derive_rustcrypto_hasher!(::sha2::Sha512, Sha2_512, 64);
 }
 
 #[cfg(feature = "sha3")]
 pub mod sha3 {
     use super::*;
 
-    derive_rustcrypto_hasher!(sha_3::Sha3_224, Sha3_224, 28);
-    derive_rustcrypto_hasher!(sha_3::Sha3_256, Sha3_256, 32);
-    derive_rustcrypto_hasher!(sha_3::Sha3_384, Sha3_384, 48);
-    derive_rustcrypto_hasher!(sha_3::Sha3_512, Sha3_512, 64);
+    derive_rustcrypto_hasher!(::sha3::Sha3_224, Sha3_224, 28);
+    derive_rustcrypto_hasher!(::sha3::Sha3_256, Sha3_256, 32);
+    derive_rustcrypto_hasher!(::sha3::Sha3_384, Sha3_384, 48);
+    derive_rustcrypto_hasher!(::sha3::Sha3_512, Sha3_512, 64);
 
-    derive_rustcrypto_hasher!(sha_3::Keccak224, Keccak224, 28);
-    derive_rustcrypto_hasher!(sha_3::Keccak256, Keccak256, 32);
-    derive_rustcrypto_hasher!(sha_3::Keccak384, Keccak384, 48);
-    derive_rustcrypto_hasher!(sha_3::Keccak512, Keccak512, 64);
+    derive_rustcrypto_hasher!(::sha3::Keccak224, Keccak224, 28);
+    derive_rustcrypto_hasher!(::sha3::Keccak256, Keccak256, 32);
+    derive_rustcrypto_hasher!(::sha3::Keccak384, Keccak384, 48);
+    derive_rustcrypto_hasher!(::sha3::Keccak512, Keccak512, 64);
 }
 
 #[cfg(feature = "ripemd")]
 pub mod ripemd {
-
     use super::*;
 
     derive_rustcrypto_hasher!(ripemd_rs::Ripemd160, Ripemd160, 20);

--- a/src/hasher_impl.rs
+++ b/src/hasher_impl.rs
@@ -230,9 +230,9 @@ pub mod sha3 {
 pub mod ripemd {
     use super::*;
 
-    derive_rustcrypto_hasher!(ripemd_rs::Ripemd160, Ripemd160, 20);
-    derive_rustcrypto_hasher!(ripemd_rs::Ripemd256, Ripemd256, 32);
-    derive_rustcrypto_hasher!(ripemd_rs::Ripemd320, Ripemd320, 40);
+    derive_rustcrypto_hasher!(::ripemd::Ripemd160, Ripemd160, 20);
+    derive_rustcrypto_hasher!(::ripemd::Ripemd256, Ripemd256, 32);
+    derive_rustcrypto_hasher!(::ripemd::Ripemd320, Ripemd320, 40);
 }
 
 pub mod identity {

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -238,7 +238,10 @@ impl<const S: usize> Multihash<S> {
     ///
     /// let hash = Code::Sha3_256.digest(b"Hello world!");
     /// let (.., arr, size) = hash.into_inner();
-    /// let foo = Foo { arr, len: size as usize };
+    /// let foo = Foo {
+    ///     arr,
+    ///     len: size as usize,
+    /// };
     /// ```
     pub fn into_inner(self) -> (u64, [u8; S], u8) {
         let Self { code, digest, size } = self;


### PR DESCRIPTION
and some trivial things:

- use `sha1` instead of `sha-1` dependency
- update `strobe-rs` v0.7.0 ==> v0.8.1
- update `serde-big-array` v0.3.2 ==> v0.4.1
- update `multihash-derive` to edition 2021
- move the `resolver = "2"` to workspace

