### PR TITLE
Add cargo deny to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,28 @@ jobs:
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
+
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Install cargo-deny
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-deny
+
+      - name: Cargo Deny - Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: deny
+          args: check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,52 @@
+
+[advisories]
+ignore = [
+    # https://rustsec.org/advisories/RUSTSEC-2021-0145
+    # 1. On windows, `atty` dereferences a potentially unaligned pointer.
+    # 2. Last release of `atty` was almost 3 years ago.
+    "RUSTSEC-2021-0145",
+
+    # https://rustsec.org/advisories/RUSTSEC-2021-0127
+    # 1. serde_cbor is unmaintained
+    "RUSTSEC-2021-0127"
+]
+notice = "deny"
+unmaintained = "warn"
+vulnerability = "deny"
+yanked = "deny"
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "MIT",
+    "Unicode-DFS-2016",
+]
+default = "deny"
+confidence-threshold = 1.0
+unlicensed = "deny"
+
+[bans]
+allow = []
+deny = []
+# TODO before changing to 'deny':
+#   * Resolve duplicate versions of itoa (used by criterion)
+#   * Remove atty from criterion
+#   * Resolve duplicate versions of constant_time_eq (used by blake2_sid and blake3)
+multiple-versions = "warn"
+skip = []
+skip-tree = []
+wildcards = "warn"
+
+[sources]
+allow-git = []
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+unknown-git = "deny"
+unknown-registry = "deny"
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
1. Locks the list of allowed licenses to the current set of dependency licenses
2. Surfaces two advisories as warnings (comments added to `deny.yml` for both)
3. Surfaces duplicate versions of the same dependency as warnings (comments added to `deny.yml` for both)

One of the advisories is for `atty` a dependency of `criterion` and tracked in an [issue in the criterion repo](https://github.com/bheisler/criterion.rs/pull/628).