### PR TITLE
Disable tarpaulin due to Node 12 deprecation breaking it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,27 +75,30 @@ jobs:
           command: build
           args: --no-default-features --workspace --target thumbv6m-none-eabi
 
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v3
+# Tarpaulin requires an upgrade (that has not been released yet) to support Node 16.
+# See https://github.com/actions-rs/tarpaulin/issues/21
 
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Generate Code Coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: --all-features
-
-      - name: Upload Code Coverage
-        uses: codecov/codecov-action@v3
+#  coverage:
+#    name: Code Coverage
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Sources
+#        uses: actions/checkout@v3
+#
+#      - name: Install Rust Toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          override: true
+#
+#      - name: Generate Code Coverage
+#        uses: actions-rs/tarpaulin@v0.1
+#        with:
+#          args: --all-features
+#
+#      - name: Upload Code Coverage
+#        uses: codecov/codecov-action@v3
 
   cargo-deny:
     name: Cargo Deny

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -250,7 +250,7 @@ impl<const S: usize> Multihash<S> {
 }
 
 // Don't hash the whole allocated space, but just the actual digest
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl<const S: usize> core::hash::Hash for Multihash<S> {
     fn hash<T: core::hash::Hasher>(&self, state: &mut T) {
         self.code.hash(state);


### PR DESCRIPTION
See [tarpaulin #21](https://github.com/actions-rs/tarpaulin/issues/21)

Problem manifests as `Error: Cannot read property 'find' of undefined`

A [PR for tarpaulin](https://github.com/actions-rs/tarpaulin/pull/22) is submitted but not merged and release yet.

Another user [replaced tarpaulin](https://github.com/actions-rs/tarpaulin/issues/21#issuecomment-1366105202) with `grcov`.