### PR TITLE
feat(codetable): remove `identity` hasher

### DIFF
--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -15,7 +15,6 @@ sha1 = ["dep:sha-1"]
 strobe = ["dep:strobe-rs"]
 blake2b = ["dep:blake2b_simd"]
 blake2s = ["dep:blake2s_simd"]
-identity = []
 
 [dependencies]
 blake2b_simd = { version = "1.0.0", default-features = false, optional = true }

--- a/codetable/src/hasher_impl.rs
+++ b/codetable/src/hasher_impl.rs
@@ -223,55 +223,6 @@ pub mod ripemd {
     derive_rustcrypto_hasher!(::ripemd::Ripemd320, Ripemd320, 40);
 }
 
-#[cfg(feature = "identity")]
-pub mod identity {
-    /// Identity hasher with a maximum size.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the input is bigger than the maximum size.
-    #[derive(Debug)]
-    pub struct IdentityHasher<const S: usize> {
-        i: usize,
-        bytes: [u8; S],
-    }
-
-    impl<const S: usize> Default for IdentityHasher<S> {
-        fn default() -> Self {
-            Self {
-                i: 0,
-                bytes: [0u8; S],
-            }
-        }
-    }
-
-    impl<const S: usize> multihash_derive::Hasher for IdentityHasher<S> {
-        fn update(&mut self, input: &[u8]) {
-            let start = self.i.min(self.bytes.len());
-            let end = (self.i + input.len()).min(self.bytes.len());
-            self.bytes[start..end].copy_from_slice(input);
-            self.i = end;
-        }
-
-        fn finalize(&mut self) -> &[u8] {
-            &self.bytes[..self.i]
-        }
-
-        fn reset(&mut self) {
-            self.i = 0
-        }
-    }
-
-    derive_write!(IdentityHasher);
-
-    /// 32 byte Identity hasher (constrained to 32 bytes).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the input is bigger than 32 bytes.
-    pub type Identity256 = IdentityHasher<32>;
-}
-
 #[cfg(feature = "strobe")]
 pub mod strobe {
     use strobe_rs::{SecParam, Strobe};

--- a/codetable/src/lib.rs
+++ b/codetable/src/lib.rs
@@ -10,8 +10,6 @@ pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bHasher};
 pub use crate::hasher_impl::blake2s::{Blake2s128, Blake2s256, Blake2sHasher};
 #[cfg(feature = "blake3")]
 pub use crate::hasher_impl::blake3::{Blake3Hasher, Blake3_256};
-#[cfg(feature = "identity")]
-pub use crate::hasher_impl::identity::{Identity256, IdentityHasher};
 #[cfg(feature = "ripemd")]
 pub use crate::hasher_impl::ripemd::{Ripemd160, Ripemd256, Ripemd320};
 #[cfg(feature = "sha1")]

--- a/codetable/src/lib.rs
+++ b/codetable/src/lib.rs
@@ -107,12 +107,6 @@ pub enum Code {
     #[cfg(feature = "ripemd")]
     #[mh(code = 0x1055, hasher = crate::Ripemd320)]
     Ripemd320,
-
-    // The following hashes are not cryptographically secure hashes and are not enabled by default
-    /// Identity hash (max. 64 bytes)
-    #[cfg(feature = "identity")]
-    #[mh(code = 0x00, hasher = crate::IdentityHasher::<64>)]
-    Identity,
 }
 
 #[cfg(test)]

--- a/codetable/tests/lib.rs
+++ b/codetable/tests/lib.rs
@@ -1,17 +1,15 @@
 use std::io::{Cursor, Write};
 
 use multihash_codetable::{
-    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Blake3_256, Identity256, Keccak224, Keccak256,
-    Keccak384, Keccak512, Ripemd160, Ripemd256, Ripemd320, Sha1, Sha2_256, Sha2_512, Sha3_224,
-    Sha3_256, Sha3_384, Sha3_512, Strobe256, Strobe512,
+    Blake2b256, Blake2b512, Blake2s128, Blake2s256, Blake3_256, Keccak224, Keccak256, Keccak384,
+    Keccak512, Ripemd160, Ripemd256, Ripemd320, Sha1, Sha2_256, Sha2_512, Sha3_224, Sha3_256,
+    Sha3_384, Sha3_512, Strobe256, Strobe512,
 };
 use multihash_derive::{Hasher, MultihashDigest};
 
 #[derive(Clone, Copy, Debug, Eq, MultihashDigest, PartialEq)]
 #[mh(alloc_size = 64)]
 pub enum Code {
-    #[mh(code = 0x00, hasher = Identity256)]
-    Identity,
     #[mh(code = 0x11, hasher = Sha1)]
     Sha1,
     #[mh(code = 0x12, hasher = Sha2_256)]
@@ -88,7 +86,6 @@ macro_rules! assert_encode {
 #[test]
 fn multihash_encode() {
     assert_encode! {
-        Identity256, Code::Identity, b"beep boop", "00096265657020626f6f70";
         Sha1, Code::Sha1, b"beep boop", "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
         Sha2_256, Code::Sha2_256, b"helloworld", "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
         Sha2_256, Code::Sha2_256, b"beep boop", "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
@@ -132,7 +129,6 @@ macro_rules! assert_decode {
 #[test]
 fn assert_decode() {
     assert_decode! {
-        Code::Identity, "000a68656c6c6f776f726c64";
         Code::Sha1, "11147c8357577f51d4f0a8d393aa1aaafb28863d9421";
         Code::Sha2_256, "1220936a185caaa266bb9cbe981e9e05cb78cd732b0b3280eb944412bb6f8f8f07af";
         Code::Sha2_256, "122090ea688e275d580567325032492b597bc77221c62493e76330b85ddda191ef7c";
@@ -198,7 +194,6 @@ macro_rules! assert_roundtrip {
 #[test]
 fn assert_roundtrip() {
     assert_roundtrip!(
-        Code::Identity, Identity256;
         Code::Sha1, Sha1;
         Code::Sha2_256, Sha2_256;
         Code::Sha2_512, Sha2_512;
@@ -255,7 +250,6 @@ where
 
 #[test]
 fn test_multihash_methods() {
-    multihash_methods::<Identity256>(Code::Identity, "000b", "68656c6c6f20776f726c64");
     multihash_methods::<Sha1>(
         Code::Sha1,
         "1114",
@@ -348,14 +342,6 @@ fn test_multihash_methods() {
             "0e12fe7d075f8e319e07c106917eddb0135e9a10aefb50a8a07ccb0582ff1fa27b95ed5af57fd5c6",
         );
     }
-}
-
-#[test]
-#[should_panic]
-fn test_long_identity_hash() {
-    // The identity hash allocates if the input size is bigger than the maximum size
-    let input = b"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz";
-    Code::Identity.digest(input);
 }
 
 #[test]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,4 +17,4 @@ core2 = { version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0.80"
-multihash-codetable = { path = "../codetable", features = ["strobe", "identity"] }
+multihash-codetable = { path = "../codetable", features = ["strobe"] }

--- a/derive/tests/pass/derive.rs
+++ b/derive/tests/pass/derive.rs
@@ -3,15 +3,12 @@ use multihash_derive::MultihashDigest;
 #[derive(Clone, Debug, Eq, PartialEq, Copy, MultihashDigest)]
 #[mh(alloc_size = 32)]
 pub enum Code {
-    #[mh(code = 0x0, hasher = multihash_codetable::Identity256)]
-    Identity256,
     /// Multihash array for hash function.
     #[mh(code = 0x38b64f, hasher = multihash_codetable::Strobe256)]
     Strobe256,
 }
 
 fn main() {
-    assert_multihash_size_32(Code::Identity256.digest(&[]));
     assert_multihash_size_32(Code::Strobe256.digest(&[]));
 }
 

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -1,0 +1,9 @@
+use multihash::Multihash;
+
+fn main() {
+    let valid_identity_hash = Multihash::<64>::wrap(0, b"foobar").unwrap();
+    let invalid_identity_hash = Multihash::<2>::wrap(0, b"foobar");
+
+    assert_eq!(valid_identity_hash.digest(), b"foobar");
+    assert_eq!(invalid_identity_hash.unwrap_err().to_string(), "Invalid multihash size 6.");
+}

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -1,5 +1,3 @@
-use multihash::Multihash;
-
 //! An example for how to use the "identity" hash of [`Multihash`].
 //!
 //! Identity hashing means we don't actually perform any hashing.
@@ -13,6 +11,8 @@ use multihash::Multihash;
 //! 2. If yes, store the data inline.
 //! 3. If no, hash it make it fit into the provided buffer.
 
+use multihash::Multihash;
+
 /// See <https://github.com/multiformats/multicodec/blob/master/table.csv#L2> for reference.
 const IDENTITY_HASH_CODE: u64 = 0;
 
@@ -21,5 +21,8 @@ fn main() {
     let invalid_identity_hash = Multihash::<2>::wrap(IDENTITY_HASH_CODE, b"foobar");
 
     assert_eq!(valid_identity_hash.digest(), b"foobar");
-    assert_eq!(invalid_identity_hash.unwrap_err().to_string(), "Invalid multihash size 6.");
+    assert_eq!(
+        invalid_identity_hash.unwrap_err().to_string(),
+        "Invalid multihash size 6."
+    );
 }

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -13,9 +13,12 @@ use multihash::Multihash;
 //! 2. If yes, store the data inline.
 //! 3. If no, hash it make it fit into the provided buffer.
 
+/// See <https://github.com/multiformats/multicodec/blob/master/table.csv#L2> for reference.
+const IDENTITY_HASH_CODE: u64 = 0;
+
 fn main() {
-    let valid_identity_hash = Multihash::<64>::wrap(0, b"foobar").unwrap();
-    let invalid_identity_hash = Multihash::<2>::wrap(0, b"foobar");
+    let valid_identity_hash = Multihash::<64>::wrap(IDENTITY_HASH_CODE, b"foobar").unwrap();
+    let invalid_identity_hash = Multihash::<2>::wrap(IDENTITY_HASH_CODE, b"foobar");
 
     assert_eq!(valid_identity_hash.digest(), b"foobar");
     assert_eq!(invalid_identity_hash.unwrap_err().to_string(), "Invalid multihash size 6.");

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -1,6 +1,6 @@
 use multihash::Multihash;
 
-//! An example for how to use the "identity" hash of `Multihash`.
+//! An example for how to use the "identity" hash of [`Multihash`].
 //!
 //! Identity hashing means we don't actually perform any hashing.
 //! Instead, we just store data directly in place of the "digest".

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -17,12 +17,9 @@ use multihash::Multihash;
 const IDENTITY_HASH_CODE: u64 = 0;
 
 fn main() {
-    let valid_identity_hash = Multihash::<64>::wrap(IDENTITY_HASH_CODE, b"foobar").unwrap();
-    let invalid_identity_hash = Multihash::<2>::wrap(IDENTITY_HASH_CODE, b"foobar");
+    let identity_hash = Multihash::<64>::wrap(IDENTITY_HASH_CODE, b"foobar").unwrap();
+    let wrap_err = Multihash::<2>::wrap(IDENTITY_HASH_CODE, b"foobar").unwrap_err();
 
-    assert_eq!(valid_identity_hash.digest(), b"foobar");
-    assert_eq!(
-        invalid_identity_hash.unwrap_err().to_string(),
-        "Invalid multihash size 6."
-    );
+    assert_eq!(identity_hash.digest(), b"foobar");
+    assert_eq!(wrap_err.to_string(), "Invalid multihash size 6.");
 }

--- a/examples/identity.rs
+++ b/examples/identity.rs
@@ -1,5 +1,18 @@
 use multihash::Multihash;
 
+//! An example for how to use the "identity" hash of `Multihash`.
+//!
+//! Identity hashing means we don't actually perform any hashing.
+//! Instead, we just store data directly in place of the "digest".
+//!
+//! [`Multihash::wrap`] returns an error in case the provided digest is too big for the available space.
+//! Make sure you construct a [`Multihash`] with a large enough buffer for your data.
+//!
+//! Typically, the way you want to use the "identity" hash is:
+//! 1. Check if your data is smaller than whatever buffer size you chose.
+//! 2. If yes, store the data inline.
+//! 3. If no, hash it make it fit into the provided buffer.
+
 fn main() {
     let valid_identity_hash = Multihash::<64>::wrap(0, b"foobar").unwrap();
     let invalid_identity_hash = Multihash::<2>::wrap(0, b"foobar");


### PR DESCRIPTION
This itself is not a breaking changes because `multihash-codetable` isn't released yet. We add an example to `multihash` on how to do identity hashing.

Resolves #194.
Replaces #196.
Replaces #201.
Replaces #260.