### PR TITLE
fix: don't panic on non minimal varints

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -61,11 +61,11 @@ pub(crate) fn unsigned_variant_to_multihash_error(err: unsigned_varint::io::Read
 }
 
 #[cfg(not(feature = "std"))]
-impl From<unsigned_varint::decode::Error> for Error {
-    fn from(error: unsigned_varint::decode::Error) -> Self {
-        Error {
-            kind: Kind::Varint(error),
-        }
+pub(crate) fn unsigned_varint_decode_to_multihash_error(
+    err: unsigned_varint::decode::Error,
+) -> Error {
+    Error {
+        kind: Kind::Varint(err),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,15 @@ pub(crate) fn unsigned_variant_to_multihash_error(err: unsigned_varint::io::Read
     }
 }
 
+#[cfg(not(feature = "std"))]
+impl From<unsigned_varint::decode::Error> for Error {
+    fn from(error: unsigned_varint::decode::Error) -> Self {
+        Error {
+            kind: Kind::Varint(error),
+        }
+    }
+}
+
 pub(crate) fn io_to_multihash_error(err: io::Error) -> Error {
     Error {
         kind: Kind::Io(err),

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -309,7 +309,7 @@ pub(crate) fn read_u64<R: io::Read>(mut r: R) -> Result<u64, Error> {
         } else if decode::is_last(b[i]) {
             return decode::u64(&b[..=i])
                 .map(|decoded| decoded.0)
-                .map_err(Into::into);
+                .map_err(crate::error::unsigned_varint_decode_to_multihash_error);
         }
     }
     Err(Error::varint_overflow())

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -307,7 +307,9 @@ pub(crate) fn read_u64<R: io::Read>(mut r: R) -> Result<u64, Error> {
         if n == 0 {
             return Err(Error::insufficient_varint_bytes());
         } else if decode::is_last(b[i]) {
-            return Ok(decode::u64(&b[..=i]).unwrap().0);
+            return decode::u64(&b[..=i])
+                .map(|decoded| decoded.0)
+                .map_err(Into::into);
         }
     }
     Err(Error::varint_overflow())
@@ -353,5 +355,13 @@ mod tests {
         let mh1 = Multihash::<32>::default();
         let mh2 = Multihash::<64>::default();
         assert_eq!(mh1, mh2);
+    }
+
+    #[test]
+    fn decode_non_minimal_error() {
+        // This is a non-minimal varint.
+        let data = [241, 0, 0, 0, 0, 0, 128, 132, 132, 132, 58];
+        let result = read_u64(&data[..]);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
If a varint it non-minimally encoded in a no_std environment, don't panic, but return an error.

Fixes #282.