### PR TITLE
fix: don't panic on non minimal varints

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -231,7 +231,7 @@ where
     H: Hasher + Default,
 {
     let digest = hex::decode(digest_str).unwrap();
-    let expected_bytes = hex::decode(&format!("{}{}", prefix, digest_str)).unwrap();
+    let expected_bytes = hex::decode(format!("{}{}", prefix, digest_str)).unwrap();
     let mut expected_cursor = Cursor::new(&expected_bytes);
     let multihash = code.digest(b"hello world");
 


### PR DESCRIPTION
If a varint it non-minimally encoded in a no_std environment, don't panic, but return an error.

Fixes #282.