### PR TITLE
fix(ci): switch to tarpaulin docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Generate Code Coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: 0.25.2
           args: --all-features
 
       - name: Upload Code Coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable]
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+        toolchain: [ stable ]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -78,22 +78,16 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:0.25.2
+      options: --security-opt seccomp=unconfined
     steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Generate Code Coverage
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: 0.25.2
-          args: --all-features
+      - name: Generate code coverage
+        run: |
+          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,8 +86,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate code coverage
-        run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+        run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
This PR fixes the coverage job by switching to the tarpaulin docker container from the (unmaintained) Github action.