### PR TITLE
chore: add a release.toml file

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,1 @@
+consolidate-commits = false


### PR DESCRIPTION
The `consolidate-commits = false` option makes sure that each crate gets its own tag with a commit message that contains its version number. Without this setting, it would only say "Release" without further information.