### PR TITLE
chore: fix type in function name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ enum Kind {
 }
 
 #[cfg(feature = "std")]
-pub(crate) fn unsigned_variant_to_multihash_error(err: unsigned_varint::io::ReadError) -> Error {
+pub(crate) fn unsigned_varint_to_multihash_error(err: unsigned_varint::io::ReadError) -> Error {
     match err {
         unsigned_varint::io::ReadError::Io(err) => io_to_multihash_error(err),
         unsigned_varint::io::ReadError::Decode(err) => Error {

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -290,7 +290,7 @@ where
 
 #[cfg(feature = "std")]
 pub(crate) fn read_u64<R: io::Read>(r: R) -> Result<u64, Error> {
-    unsigned_varint::io::read_u64(r).map_err(crate::error::unsigned_variant_to_multihash_error)
+    unsigned_varint::io::read_u64(r).map_err(crate::error::unsigned_varint_to_multihash_error)
 }
 
 /// Reads 64 bits from a byte array into a u64


### PR DESCRIPTION
It should be "varint" and not "variant".

That's one for @thomaseizinger :)