### PR TITLE
feat: Serde serialize Multihash in bytes representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,13 @@ alloc = []
 arb = ["dep:quickcheck", "dep:rand", "dep:arbitrary"]
 scale-codec = ["dep:parity-scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.
-serde = ["dep:serde", "dep:serde-big-array"]
+serde = ["dep:serde"]
 
 [dependencies]
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 rand = { version = "0.8.5", optional = true, features = ["small_rng"] }
 serde = { version = "1.0.116", optional = true, default-features = false, features = ["derive"] }
-serde-big-array = { version = "0.5.1", optional = true }
 unsigned-varint = { version = "0.7.1", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
 
@@ -41,3 +40,4 @@ serde_json = "1.0.58"
 quickcheck = "1.0.3"
 rand = "0.8.5"
 arbitrary = "1.1.0"
+serde_test = "1.0.160"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = ["dep:serde"]
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
 rand = { version = "0.8.5", optional = true, features = ["small_rng"] }
-serde = { version = "1.0.116", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0.116", optional = true, default-features = false }
 unsigned-varint = { version = "0.7.1", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ extern crate alloc;
 mod arb;
 mod error;
 mod multihash;
+#[cfg(feature = "serde")]
+mod serde;
 
 /// Multihash result.
 #[deprecated(note = "Use `Result<T, multihash::Error>` instead")]

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -34,8 +34,6 @@ use core2::io;
 /// assert_eq!(mh.size(), 32);
 /// assert_eq!(mh.digest(), &digest_bytes[2..]);
 /// ```
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialOrd)]
 pub struct Multihash<const S: usize> {
     /// The code of the Multihash.
@@ -43,7 +41,6 @@ pub struct Multihash<const S: usize> {
     /// The actual size of the digest in bytes (not the allocated size).
     size: u8,
     /// The digest.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     digest: [u8; S],
 }
 
@@ -339,15 +336,6 @@ mod tests {
         assert_eq!(mh3, mh4);
 
         assert_eq!(mh1_bytes, mh3_bytes);
-    }
-
-    #[test]
-    #[cfg(feature = "serde")]
-    fn test_serde() {
-        let mh = Multihash::<32>::default();
-        let bytes = serde_json::to_string(&mh).unwrap();
-        let mh2: Multihash<32> = serde_json::from_str(&bytes).unwrap();
-        assert_eq!(mh, mh2);
     }
 
     #[test]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,175 @@
+//! Multihash Serde (de)serialization
+
+use std::fmt;
+
+use serde::{
+    de::{self, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use crate::Multihash;
+
+impl<const SIZE: usize> Serialize for Multihash<SIZE> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.to_bytes())
+    }
+}
+
+struct BytesVisitor<const SIZE: usize>;
+
+impl<'de, const SIZE: usize> Visitor<'de> for BytesVisitor<SIZE> {
+    type Value = Multihash<SIZE>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "a valid Multihash in bytes")
+    }
+
+    fn visit_bytes<E>(self, bytes: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Multihash::<SIZE>::from_bytes(bytes)
+            .map_err(|err| de::Error::custom(format!("Failed to deserialize Multihash: {}", err)))
+    }
+
+    // Some Serde data formats interpret a byte stream as a sequence of bytes (e.g. `serde_json`).
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut bytes = Vec::new();
+        while let Some(byte) = seq.next_element()? {
+            bytes.push(byte);
+        }
+        Multihash::<SIZE>::from_bytes(&bytes)
+            .map_err(|err| de::Error::custom(format!("Failed to deserialize Multihash: {}", err)))
+    }
+}
+
+impl<'de, const SIZE: usize> Deserialize<'de> for Multihash<SIZE> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(BytesVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_test::{assert_tokens, Token};
+
+    const SHA2_256_CODE: u64 = 0x12;
+    const DIGEST: [u8; 32] = [
+        159, 228, 204, 198, 222, 22, 114, 79, 58, 48, 199, 232, 242, 84, 243, 198, 71, 25, 134,
+        172, 177, 248, 216, 207, 142, 150, 206, 42, 215, 219, 231, 251,
+    ];
+
+    #[test]
+    fn test_serde_json() {
+        // This is a concatenation of `SHA2_256_CODE + DIGEST_LENGTH + DIGEST`.
+        let expected_json = format!("[{},{},159,228,204,198,222,22,114,79,58,48,199,232,242,84,243,198,71,25,134,172,177,248,216,207,142,150,206,42,215,219,231,251]", SHA2_256_CODE as u8, DIGEST.len() as u8);
+
+        let mh = Multihash::<32>::wrap(SHA2_256_CODE, &DIGEST).unwrap();
+
+        let json = serde_json::to_string(&mh).unwrap();
+        assert_eq!(json, expected_json);
+
+        let mh_decoded: Multihash<32> = serde_json::from_str(&json).unwrap();
+        assert_eq!(mh, mh_decoded);
+    }
+
+    #[test]
+    fn test_serde_test() {
+        // This is a concatenation of `SHA2_256_CODE + DIGEST_LENGTH + DIGEST`.
+        const ENCODED_MULTIHASH_BYTES: [u8; 34] = [
+            SHA2_256_CODE as u8,
+            DIGEST.len() as u8,
+            159,
+            228,
+            204,
+            198,
+            222,
+            22,
+            114,
+            79,
+            58,
+            48,
+            199,
+            232,
+            242,
+            84,
+            243,
+            198,
+            71,
+            25,
+            134,
+            172,
+            177,
+            248,
+            216,
+            207,
+            142,
+            150,
+            206,
+            42,
+            215,
+            219,
+            231,
+            251,
+        ];
+
+        let mh = Multihash::<32>::wrap(SHA2_256_CODE, &DIGEST).unwrap();
+
+        // As bytes.
+        assert_tokens(&mh, &[Token::Bytes(&ENCODED_MULTIHASH_BYTES)]);
+
+        // As sequence.
+        serde_test::assert_de_tokens(
+            &mh,
+            &[
+                Token::Seq { len: Some(34) },
+                Token::U8(SHA2_256_CODE as u8),
+                Token::U8(DIGEST.len() as u8),
+                Token::U8(159),
+                Token::U8(228),
+                Token::U8(204),
+                Token::U8(198),
+                Token::U8(222),
+                Token::U8(22),
+                Token::U8(114),
+                Token::U8(79),
+                Token::U8(58),
+                Token::U8(48),
+                Token::U8(199),
+                Token::U8(232),
+                Token::U8(242),
+                Token::U8(84),
+                Token::U8(243),
+                Token::U8(198),
+                Token::U8(71),
+                Token::U8(25),
+                Token::U8(134),
+                Token::U8(172),
+                Token::U8(177),
+                Token::U8(248),
+                Token::U8(216),
+                Token::U8(207),
+                Token::U8(142),
+                Token::U8(150),
+                Token::U8(206),
+                Token::U8(42),
+                Token::U8(215),
+                Token::U8(219),
+                Token::U8(231),
+                Token::U8(251),
+                Token::SeqEnd,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Multihash has a defined bytes representation, serialize it as such one instead of deriving it from the internal representation. This way there is no leak of internal implementation details.

BREAKING CHANGE: The Serde serialization format changed