### PR TITLE
Expose `MultihashDigest` trait in codetable

### DIFF
--- a/codetable/src/lib.rs
+++ b/codetable/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod hasher_impl;
 
-use multihash_derive::MultihashDigest;
+pub use multihash_derive::MultihashDigest;
 
 #[cfg(feature = "blake2b")]
 pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bHasher};


### PR DESCRIPTION
Can't use any methods without exposing the trait implemented from deriving.

e.g. `Code::try_from(0x12).digest(&[0xb0, 0xba])`