### PR TITLE
chore: update release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [v0.18.1](https://github.com/multiformats/rust-multihash/compare/v0.18.0...v0.18.1) (2023-04-14)
+## [v0.18.1](https://github.com/multiformats/rust-multihash/compare/v0.18.0...v0.18.1) (2023-04-14)
 
 
 ### Bug Fixes
@@ -6,7 +6,20 @@
 * don't panic on non minimal varints ([#293](https://github.com/multiformats/rust-multihash/issues/293)) ([c3445fc](https://github.com/multiformats/rust-multihash/commit/c3445fc5041b0fc573945321ebd4b0cdffe0daa5)), closes [#282](https://github.com/multiformats/rust-multihash/issues/282)
 
 
-# [v0.18.0](https://github.com/multiformats/rust-multihash/compare/v0.17.0...v) (2022-12-06)
+## [0.18.0](https://github.com/multiformats/rust-multihash/compare/v0.17.0...v0.18.0) (2022-12-06)
+
+
+### ⚠ BREAKING CHANGES
+
+* update to Rust edition 2021
+* `Multihash::write()` returns bytes written
+
+    Prior to this change it returned an empty tuple `()`, now it returns
+the bytes written.
+
+### Features
+
+* add `encoded_len` and bytes written ([#252](https://github.com/multiformats/rust-multihash/issues/252)) ([b3cc43e](https://github.com/multiformats/rust-multihash/commit/b3cc43ecb6f9c59da774b094853d6542430d55ad))
 
 
 ### Bug Fixes
@@ -14,16 +27,3 @@
 * remove Nix support ([#254](https://github.com/multiformats/rust-multihash/issues/254)) ([ebf57dd](https://github.com/multiformats/rust-multihash/commit/ebf57ddb82be2d2fd0a2f00666b0f888d4c78e1b)), closes [#247](https://github.com/multiformats/rust-multihash/issues/247)
 * update to Rust edition 2021 ([#255](https://github.com/multiformats/rust-multihash/issues/255)) ([da53376](https://github.com/multiformats/rust-multihash/commit/da53376e0d9cf2d82d6c0d10590a77991cb3a6b6))
 
-
-### Features
-
-* add `encoded_len` and bytes written ([#252](https://github.com/multiformats/rust-multihash/issues/252)) ([b3cc43e](https://github.com/multiformats/rust-multihash/commit/b3cc43ecb6f9c59da774b094853d6542430d55ad))
-
-
-### BREAKING CHANGES
-
-* update to Rust edition 2021
-* `Multihash::write()` returns bytes written
-
-    Prior to this change it returned an empty tuple `()`, now it returns
-the bytes written.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,10 +9,11 @@ Install dependencies
 ```sh
 $ npm install -g conventional-changelog-cli
 $ cd rust-multihash
-$ conventional-changelog --preset angular
+$ conventional-changelog --preset conventionalcommits
 ```
 
-Add the output of that to `CHANGELOG.md`, and write a human-centric summary of changes.
+Add the output of that to `CHANGELOG.md`. Write a human-centric summary of changes and add migration instructions for breaking changes if needed.
+
 Update the linked output to reference the new version, which conventional-changelog doesn't know about:
 
 ```md


### PR DESCRIPTION
Make it clearer that the changelog is the place for explaining migrations.

Also change the changelog from angular to the conventionalcommits style as mentioned at
https://github.com/multiformats/rust-multihash/pull/276#issuecomment-1479206358.