### PR TITLE
chore: increase MSRV to 1.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/multihash/"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
`toml_datetime` v0.6.2 needs Rust 1.64 as minimum supported Rust version, hence also update to that one.

This is not considered a breaking change as we haven't specified a MSRV in previous releases.