### PR TITLE
chore(.github): add semver-checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,3 +135,11 @@ jobs:
         with:
           command: deny
           args: check
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
Adds `cargo semver-checks`, linting crate API changes for semver violations.

Fixes https://github.com/multiformats/rust-multihash/issues/307

This should do the trick, right @thomaseizinger?