### PR TITLE
feat: don't activate features for MSRV check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo +"$MSRV" build --all-features --package multihash
+      - run: cargo +"$MSRV" build --package multihash
 
   coverage:
     name: Code Coverage

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ multihash = "*"
 
 Then run `cargo build`.
 
-MSRV 1.51.0 due to use of const generics
-
 ## Usage
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ multihash = "*"
 
 Then run `cargo build`.
 
+## MSRV
+
+The minimum supported Rust version for this library is `1.64.0`.
+This is only guaranteed without additional features activated.
+
 ## Usage
 
 ```rust


### PR DESCRIPTION
We only activate `std` by default and don't use any very recent std features. Other features will bring in dependencies where we don't control the MSRV policy. Thus, we don't guarantee a MSRV with features activated.

Resolves #317.