### PR TITLE
docs: make README not terribly outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ You should set this to the maximum size of the digest you want to support.
 ```rust
 use multihash::Multihash;
 
+const SHA2_256: u64 = 0x12;
+
 fn main() {
-    let hash = Multihash::<64>::wrap(0x12, b"my digest");
-    println!("{:?}", hash);
+	let hash = Multihash::<64>::wrap(SHA2_256, b"my digest");
+	println!("{:?}", hash);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,29 +37,34 @@ MSRV 1.51.0 due to use of const generics
 
 ## Usage
 
+The `multihash` crate exposes a basic data structure for encoding and decoding multihash.
+It does not provide any hashing functionality itself.
+`Multihash` uses const-generics to define the internal buffer size.
+You should set this to the maximum size of the digest you want to support.
+
 ```rust
-use multihash::{Code, MultihashDigest};
+use multihash::Multihash;
 
 fn main() {
-    let hash = Code::Sha2_256.digest(b"my hash");
+    let hash = Multihash::<64>::wrap(0x12, b"my digest");
     println!("{:?}", hash);
 }
 ```
 
 ### Using a custom code table
 
-You can derive your own application specific code table:
+You can derive your own application specific code table using the `multihash-derive` crate.
+The `multihash-codetable` provides predefined hasher implementations if you don't want to implement your own.
 
 ```rust
-use multihash::derive::Multihash;
-use multihash::MultihashCode;
+use multihash_derive::MultihashDigest;
 
-#[derive(Clone, Copy, Debug, Eq, Multihash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, MultihashDigest, PartialEq)]
 #[mh(alloc_size = 64)]
 pub enum Code {
-    #[mh(code = 0x01, hasher = multihash::Sha2_256)]
+    #[mh(code = 0x01, hasher = multihash_codetable::Sha2_256)]
     Foo,
-    #[mh(code = 0x02, hasher = multihash::Sha2_512)]
+    #[mh(code = 0x02, hasher = multihash_codetable::Sha2_512)]
     Bar,
 }
 


### PR DESCRIPTION
Currently, the README is terribly outdated. It will likely get outdated again because the code samples in there are not type-checked.

This should do for now and hopefully unblock the `v0.19` release.