### PR TITLE
fix: make Serde (de)serialization no_std compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,22 @@ jobs:
         run: cargo build --no-default-features --workspace --target thumbv6m-none-eabi
         shell: bash
 
+  build-no-std-with-serde:
+    name: Build no_std with `serde` feature enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv6m-none-eabi
+
+      - name: Build
+        run: cargo build --no-default-features --features serde --workspace --target thumbv6m-none-eabi
+        shell: bash
+
   msrv:
     name: MSRV
     runs-on: ubuntu-latest

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -28,7 +28,7 @@ strobe-rs = { version = "0.8.1", default-features = false, optional = true }
 ripemd = { version = "0.1.1", default-features = false, optional = true }
 multihash-derive = { version = "0.9.0", path = "../derive", default-features = false }
 core2 = { version = "0.4.0", default-features = false }
-serde = { version = "1.0.158", features = ["derive"], optional = true }
+serde = { version = "1.0.158", features = ["derive"], default-features = false, optional = true }
 
 [dev-dependencies]
 hex = "0.4.2"


### PR DESCRIPTION
`multihash` v0.19 introduced a regression. It's no longer possible to compile with `no_std` and `serde` feature enabled. This commit fixes that regression.

Due to generic_const_exprs not being a thing yet, we need to use unsafe code to provide this functionality.

Fixes #336.