### PR TITLE
codetable: fix build for blake2s and blake2b features

### DIFF
--- a/codetable/src/hasher_impl.rs
+++ b/codetable/src/hasher_impl.rs
@@ -1,4 +1,10 @@
-#[cfg(any(feature = "strobe", feature = "identity", feature = "blake3"))]
+#[cfg(any(
+    feature = "strobe",
+    feature = "identity",
+    feature = "blake2b",
+    feature = "blake2s",
+    feature = "blake3"
+))]
 macro_rules! derive_write {
     ($name:ident) => {
         impl<const S: usize> core2::io::Write for $name<S> {


### PR DESCRIPTION
In the refactor where each hasher was moved to a separate feature, the conditional compilation of derive_write! was written such that enabling only blake2 hashing will result in compilation errors:

    error: cannot find macro `derive_write` in this scope
      --> /home/cyphar/.cargo/registry/src/index.crates.io-6f17d22bba15001f/multihash-codetable-0.1.0/src/hasher_impl.rs:59:9
       |
    59 |         derive_write!($name);
       |         ^^^^^^^^^^^^
    ...
    65 |     derive_hasher_blake!(blake2b_simd, Blake2bHasher);
       |     ------------------------------------------------- in this macro invocation
       |
       = note: this error originates in the macro `derive_hasher_blake` (in Nightly builds, run with -Z macro-backtrace for more info)

    error: could not compile `multihash-codetable` (lib) due to previous error

Fixes: 954e5233d273 ("refactor!: split crates into multiple to isolate breaking changes")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>