### PR TITLE
docs(codetable): expose all items with required features on docs.rs

### DIFF
--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -57,3 +57,7 @@ required-features = ["blake2b", "sha2"]
 name = "manual_mh"
 path = "examples/manual_mh.rs"
 required-features = ["sha2"]
+
+[package.metadata.docs.rs]
+features = ["std", "sha1", "sha2", "sha3", "ripemd", "strobe", "blake2b", "blake2s", "blake3", "serde"]
+rustdoc-args = ["--cfg", "docs_rs"]

--- a/codetable/src/lib.rs
+++ b/codetable/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docs_rs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //! A batteries-included code table of multihashes.
@@ -13,22 +14,30 @@ mod hasher_impl;
 pub use multihash_derive::MultihashDigest;
 
 #[cfg(feature = "blake2b")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "blake2b")))]
 pub use crate::hasher_impl::blake2b::{Blake2b256, Blake2b512, Blake2bHasher};
 #[cfg(feature = "blake2s")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "blake2s")))]
 pub use crate::hasher_impl::blake2s::{Blake2s128, Blake2s256, Blake2sHasher};
 #[cfg(feature = "blake3")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "blake3")))]
 pub use crate::hasher_impl::blake3::{Blake3Hasher, Blake3_256};
 #[cfg(feature = "ripemd")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "ripemd")))]
 pub use crate::hasher_impl::ripemd::{Ripemd160, Ripemd256, Ripemd320};
 #[cfg(feature = "sha1")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "sha1")))]
 pub use crate::hasher_impl::sha1::Sha1;
 #[cfg(feature = "sha2")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "sha2")))]
 pub use crate::hasher_impl::sha2::{Sha2_256, Sha2_512};
 #[cfg(feature = "sha3")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
 pub use crate::hasher_impl::sha3::{
     Keccak224, Keccak256, Keccak384, Keccak512, Sha3_224, Sha3_256, Sha3_384, Sha3_512,
 };
 #[cfg(feature = "strobe")]
+#[cfg_attr(docs_rs, doc(cfg(feature = "strobe")))]
 pub use crate::hasher_impl::strobe::{Strobe256, Strobe512, StrobeHasher};
 
 /// Default (cryptographically secure) Multihash implementation.
@@ -43,74 +52,92 @@ pub use crate::hasher_impl::strobe::{Strobe256, Strobe512, StrobeHasher};
 pub enum Code {
     /// SHA-256 (32-byte hash size)
     #[cfg(feature = "sha2")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha2")))]
     #[mh(code = 0x12, hasher = crate::Sha2_256)]
     Sha2_256,
     /// SHA-512 (64-byte hash size)
     #[cfg(feature = "sha2")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha2")))]
     #[mh(code = 0x13, hasher = crate::Sha2_512)]
     Sha2_512,
     /// SHA3-224 (28-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x17, hasher = crate::Sha3_224)]
     Sha3_224,
     /// SHA3-256 (32-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x16, hasher = crate::Sha3_256)]
     Sha3_256,
     /// SHA3-384 (48-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x15, hasher = crate::Sha3_384)]
     Sha3_384,
     /// SHA3-512 (64-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x14, hasher = crate::Sha3_512)]
     Sha3_512,
     /// Keccak-224 (28-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x1a, hasher = crate::Keccak224)]
     Keccak224,
     /// Keccak-256 (32-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x1b, hasher = crate::Keccak256)]
     Keccak256,
     /// Keccak-384 (48-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x1c, hasher = crate::Keccak384)]
     Keccak384,
     /// Keccak-512 (64-byte hash size)
     #[cfg(feature = "sha3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "sha3")))]
     #[mh(code = 0x1d, hasher = crate::Keccak512)]
     Keccak512,
     /// BLAKE2b-256 (32-byte hash size)
     #[cfg(feature = "blake2b")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "blake2b")))]
     #[mh(code = 0xb220, hasher = crate::Blake2b256)]
     Blake2b256,
     /// BLAKE2b-512 (64-byte hash size)
     #[cfg(feature = "blake2b")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "blake2b")))]
     #[mh(code = 0xb240, hasher = crate::Blake2b512)]
     Blake2b512,
     /// BLAKE2s-128 (16-byte hash size)
     #[cfg(feature = "blake2s")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "blake2s")))]
     #[mh(code = 0xb250, hasher = crate::Blake2s128)]
     Blake2s128,
     /// BLAKE2s-256 (32-byte hash size)
     #[cfg(feature = "blake2s")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "blake2s")))]
     #[mh(code = 0xb260, hasher = crate::Blake2s256)]
     Blake2s256,
     /// BLAKE3-256 (32-byte hash size)
     #[cfg(feature = "blake3")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "blake3")))]
     #[mh(code = 0x1e, hasher = crate::Blake3_256)]
     Blake3_256,
     /// RIPEMD-160 (20-byte hash size)
     #[cfg(feature = "ripemd")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "ripemd")))]
     #[mh(code = 0x1053, hasher = crate::Ripemd160)]
     Ripemd160,
     /// RIPEMD-256 (32-byte hash size)
     #[cfg(feature = "ripemd")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "ripemd")))]
     #[mh(code = 0x1054, hasher = crate::Ripemd256)]
     Ripemd256,
     /// RIPEMD-320 (40-byte hash size)
     #[cfg(feature = "ripemd")]
+    #[cfg_attr(docs_rs, doc(cfg(feature = "ripemd")))]
     #[mh(code = 0x1055, hasher = crate::Ripemd320)]
     Ripemd320,
 }


### PR DESCRIPTION
This change affects only builds on docs.rs. Previously docs.rs built
multihash-codetable with only the default features enabled, thus all
the content of the crate could be inspected only when reading sources.
This change exposes all items from the crate on docs.rs and labels
them with what features they require.