### PR TITLE
fix: upgrade syn and synstructure (#362)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        toolchain: [ stable ]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -100,7 +100,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.25.2
+      image: xd009642/tarpaulin:0.30.0
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository

--- a/derive-impl/Cargo.toml
+++ b/derive-impl/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro2 = { version = "1.0.24", features = ["span-locations"] }
 proc-macro-crate = "2.0.0"
 proc-macro-error = "1.0.4"
 quote = "1.0.7"
-syn = "1.0.42"
-synstructure = "0.12.4"
+syn = "2.0.66"
+synstructure = "0.13.1"

--- a/derive-impl/src/multihash.rs
+++ b/derive-impl/src/multihash.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 
 use crate::utils;
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
-#[cfg(not(test))]
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 #[cfg(not(test))]
 use syn::spanned::Spanned;

--- a/derive-impl/src/multihash.rs
+++ b/derive-impl/src/multihash.rs
@@ -97,7 +97,7 @@ impl<'a> From<&'a VariantInfo<'a>> for Hash {
         let mut code = None;
         let mut hasher = None;
         for attr in bi.ast().attrs {
-            let attr: Result<utils::Attrs<MhAttr>, _> = syn::parse2(attr.tokens.clone());
+            let attr: Result<utils::Attrs<MhAttr>, _> = syn::parse2(attr.meta.to_token_stream());
             if let Ok(attr) = attr {
                 for attr in attr.attrs {
                     match attr {
@@ -138,7 +138,9 @@ fn parse_code_enum_attrs(ast: &syn::DeriveInput) -> syn::LitInt {
     let mut alloc_size = None;
 
     for attr in &ast.attrs {
-        let derive_attrs: Result<utils::Attrs<DeriveAttr>, _> = syn::parse2(attr.tokens.clone());
+        let derive_attrs: Result<utils::Attrs<DeriveAttr>, _> =
+            syn::parse2(attr.meta.to_token_stream());
+
         if let Ok(derive_attrs) = derive_attrs {
             for derive_attr in derive_attrs.attrs {
                 match derive_attr {
@@ -192,10 +194,6 @@ fn error_code_duplicates(hashes: &[Hash]) {
         }
     });
 }
-
-/// An error that contains a span in order to produce nice error messages.
-#[derive(Debug)]
-struct ParseError(Span);
 
 pub fn multihash(s: Structure) -> TokenStream {
     let mh_crate = match utils::use_crate("multihash-derive") {

--- a/derive-impl/src/utils.rs
+++ b/derive-impl/src/utils.rs
@@ -14,16 +14,23 @@ pub fn use_crate(name: &str) -> Result<syn::Ident, Error> {
 
 #[derive(Debug)]
 pub struct Attrs<A> {
+    pub ident: syn::Ident,
     pub paren: syn::token::Paren,
     pub attrs: Punctuated<A, syn::token::Comma>,
 }
 
 impl<A: Parse> Parse for Attrs<A> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        // Maybe check if ident == "mh"
+        let ident = input.parse()?;
         let content;
         let paren = syn::parenthesized!(content in input);
-        let attrs = content.parse_terminated(A::parse)?;
-        Ok(Self { paren, attrs })
+        let attrs = content.parse_terminated(A::parse, syn::token::Comma)?;
+        Ok(Self {
+            ident,
+            paren,
+            attrs,
+        })
     }
 }
 

--- a/derive/tests/fail/no_allow_same_code_twice.stderr
+++ b/derive/tests/fail/no_allow_same_code_twice.stderr
@@ -6,3 +6,11 @@ error: the #mh(code) attribute `0x0` is defined multiple times
    |
 21 |     #[mh(code = 0x0, hasher = FooHasher)]
    |                 ^^^
+
+warning: unused variable: `input`
+ --> tests/fail/no_allow_same_code_twice.rs:7:26
+  |
+7 |     fn update(&mut self, input: &[u8]) { }
+  |                          ^^^^^ help: if this is intentional, prefix it with an underscore: `_input`
+  |
+  = note: `#[warn(unused_variables)]` on by default

--- a/derive/tests/fail/no_allow_same_name_twice.stderr
+++ b/derive/tests/fail/no_allow_same_name_twice.stderr
@@ -8,3 +8,41 @@ error[E0428]: the name `Foo` is defined multiple times
    |     ^^^ `Foo` redefined here
    |
    = note: `Foo` must be defined only once in the type namespace of this enum
+
+warning: unused variable: `input`
+ --> tests/fail/no_allow_same_name_twice.rs:7:26
+  |
+7 |     fn update(&mut self, input: &[u8]) { }
+  |                          ^^^^^ help: if this is intentional, prefix it with an underscore: `_input`
+  |
+  = note: `#[warn(unused_variables)]` on by default
+
+error[E0004]: non-exhaustive patterns: `&Code::Foo` not covered
+  --> tests/fail/no_allow_same_name_twice.rs:16:17
+   |
+16 | #[derive(Clone, Debug, Eq, PartialEq, Copy, multihash_derive::MultihashDigest)]
+   |                 ^^^^^ pattern `&Code::Foo` not covered
+   |
+note: `Code` defined here
+  --> tests/fail/no_allow_same_name_twice.rs:18:10
+   |
+18 | pub enum Code {
+   |          ^^^^
+...
+22 |     Foo,
+   |     --- not covered
+   = note: the matched value is of type `&Code`
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unreachable pattern
+  --> tests/fail/no_allow_same_name_twice.rs:18:10
+   |
+18 |   pub enum Code {
+   |  __________^
+19 | |     #[mh(code = 0x0, hasher = FooHasher)]
+20 | |     Foo,
+21 | |     #[mh(code = 0x1, hasher = FooHasher)]
+22 | |     Foo,
+   | |_______^
+   |
+   = note: `#[warn(unreachable_patterns)]` on by default


### PR DESCRIPTION
fixes #362
closes #350 
closes #301 

* I've added an `Ident` to `utils::Attrs` since `attr.meta.to_token_stream()` now includes it.
* I've also removed `ParseError` since it didn't seem to be used (and tests seemed to passed)