### PR TITLE
Derive `Arbitrary` for `multihash_codetable::Code`

### DIFF
--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [features]
 default = ["std"]
 std = ["blake2b_simd?/std", "blake2s_simd?/std", "blake3?/std", "digest?/std", "sha1?/std", "sha2?/std", "sha3?/std", "strobe-rs?/std", "ripemd?/std", "multihash-derive/std", "core2/std"]
+arb = ["dep:arbitrary", "std"]
 sha1 = ["dep:digest", "dep:sha1"]
 sha2 = ["dep:digest", "dep:sha2"]
 sha3 = ["dep:digest", "dep:sha3"]
@@ -33,6 +34,7 @@ ripemd = { version = "0.1.1", default-features = false, optional = true }
 multihash-derive = { version = "0.9.0", path = "../derive", default-features = false }
 core2 = { version = "0.4.0", default-features = false }
 serde = { version = "1.0.158", features = ["derive"], default-features = false, optional = true }
+arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/codetable/src/lib.rs
+++ b/codetable/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "arb", allow(unreachable_code))] // Otherwise the "Cargo Hack" check fails since "arb" includes no hash algos by default
 #![cfg_attr(docs_rs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -46,6 +47,7 @@ pub use crate::hasher_impl::strobe::{Strobe256, Strobe512, StrobeHasher};
 /// algorithms. See the [`multihash-derive`] crate for more information.
 ///
 /// [`multihash-derive`]: https://docs.rs/multihash-derive
+#[cfg_attr(feature = "arb", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Eq, MultihashDigest, PartialEq)]
 #[mh(alloc_size = 64)]


### PR DESCRIPTION
I found myself writing a newtype wrapper over `Code` to get an `impl proptest::Arbitrary`, and thought "hey, why don't I upstream this one-liner?"

I tried to keep to your libraries and conventions as much as possible (e.g. `arb`), but please let me know if I missed anything.

(Some of the automated checks are failing, but I'm 90% sure those failures "shouldn't" be related to this change. It's late here, so I'll double check tomorrow)