### PR TITLE
fix: fix Clippy warnings

### DIFF
--- a/derive-impl/src/utils.rs
+++ b/derive-impl/src/utils.rs
@@ -13,8 +13,12 @@ pub fn use_crate(name: &str) -> Result<syn::Ident, Error> {
 }
 
 #[derive(Debug)]
-pub struct Attrs<A> {
+pub(crate) struct Attrs<A> {
+    // The information is part of the parsed AST, we preserve it even if it isn't used yet.
+    #[allow(dead_code)]
     pub ident: syn::Ident,
+    // The information is part of the parsed AST, we preserve it even if it isn't used yet.
+    #[allow(dead_code)]
     pub paren: syn::token::Paren,
     pub attrs: Punctuated<A, syn::token::Comma>,
 }
@@ -35,8 +39,12 @@ impl<A: Parse> Parse for Attrs<A> {
 }
 
 #[derive(Debug)]
-pub struct Attr<K, V> {
+pub(crate) struct Attr<K, V> {
+    // The information is part of the parsed AST, we preserve it even if it isn't used yet.
+    #[allow(dead_code)]
     pub key: K,
+    // The information is part of the parsed AST, we preserve it even if it isn't used yet.
+    #[allow(dead_code)]
     pub eq: syn::token::Eq,
     pub value: V,
 }


### PR DESCRIPTION
There are some attributes which aren't used yet. Include them though, as they are parsed anyway.

Also communicate clearer that the attribute types are not part of the public interface, but only used internally.