### PR TITLE
chore: fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           tool: cargo-hack
 
       - name: Cargo Hack - Check each feature
-        run: cargo hack check -p multihash-codetable --each-feature
+        run: cargo hack check -p multihash-codetable --each-feature --exclude-features arb
         shell: bash
         env:
           RUSTFLAGS: -D warnings


### PR DESCRIPTION
Only enabling the `arb` feature on the `codetable` crate now fails, due to changes to the `arbitrary_derive` crate. It now errors if the enum its derived from is empty. Which it is in our case.