### PR TITLE
fix: make alloc without std work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.64"
 [features]
 default = ["std"]
 std = ["unsigned-varint/std", "alloc"]
-alloc = []
+alloc = ["core2/alloc"]
 arb = ["dep:quickcheck", "dep:rand", "dep:arbitrary"]
 scale-codec = ["dep:parity-scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.


### PR DESCRIPTION
During the refactor at 954e5233d273a2b7d682fd087178203628d131a4 the ability to compile the `multihash` crate with `alloc` but without `std` was lost. Now it works again.

Fixes #375.

The CI failure on the codetable is unrelated and has a fix at #376.