### PR TITLE
test: update error message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     container:
-      image: xd009642/tarpaulin:0.31.2
+      image: xd009642/tarpaulin:0.32.8
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository

--- a/derive/tests/fail/no_allow_same_code_twice.stderr
+++ b/derive/tests/fail/no_allow_same_code_twice.stderr
@@ -1,4 +1,4 @@
-error: the #mh(code) attribute `0x0` is defined multiple times, previous definition at line 0
+error: the #mh(code) attribute `0x0` is defined multiple times, previous definition at line 19
   --> tests/fail/no_allow_same_code_twice.rs:21:17
    |
 21 |     #[mh(code = 0x0, hasher = FooHasher)]

--- a/derive/tests/fail/no_allow_same_name_twice.stderr
+++ b/derive/tests/fail/no_allow_same_name_twice.stderr
@@ -32,7 +32,6 @@ note: `Code` defined here
 22 |     Foo,
    |     --- not covered
    = note: the matched value is of type `&Code`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unreachable pattern
   --> tests/fail/no_allow_same_name_twice.rs:18:10


### PR DESCRIPTION
The error messages changed slightly, hence update them.

Also a newer version of Tarpaulin is needed, so that it also uses those newer error messages.