### PR TITLE
Replace core2 with no_std_io2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,11 @@ description = "Implementation of the multihash format"
 repository = "https://github.com/multiformats/rust-multihash"
 keywords = ["multihash", "ipfs"]
 version = "0.19.3"
-authors = ["dignifiedquire <dignifiedquire@gmail.com>", "David Craven <david@craven.ch>", "Volker Mische <volker.mische@gmail.com>"]
+authors = [
+  "dignifiedquire <dignifiedquire@gmail.com>",
+  "David Craven <david@craven.ch>",
+  "Volker Mische <volker.mische@gmail.com>",
+]
 license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/multihash/"
@@ -21,21 +25,25 @@ all-features = true
 [features]
 default = ["std"]
 std = ["unsigned-varint/std", "alloc"]
-alloc = ["core2/alloc"]
+alloc = ["no_std_io2/alloc"]
 arb = ["dep:quickcheck", "dep:rand", "dep:arbitrary"]
 scale-codec = ["dep:parity-scale-codec"]
-serde-codec = ["serde"] # Deprecated, don't use.
+serde-codec = ["serde"]                               # Deprecated, don't use.
 serde = ["dep:serde"]
 
 [dependencies]
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = [
+  "derive",
+], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
-rand = { version = "0.10", default-features = false, features = ["alloc"], optional = true }
+rand = { version = "0.10", default-features = false, features = [
+  "alloc",
+], optional = true }
 serde = { version = "1.0.116", optional = true, default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
 
-core2 = { version = "0.4.0", default-features = false }
+no_std_io2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,7 @@ description = "Implementation of the multihash format"
 repository = "https://github.com/multiformats/rust-multihash"
 keywords = ["multihash", "ipfs"]
 version = "0.19.3"
-authors = [
-  "dignifiedquire <dignifiedquire@gmail.com>",
-  "David Craven <david@craven.ch>",
-  "Volker Mische <volker.mische@gmail.com>",
-]
+authors = ["dignifiedquire <dignifiedquire@gmail.com>", "David Craven <david@craven.ch>", "Volker Mische <volker.mische@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 documentation = "https://docs.rs/multihash/"
@@ -28,17 +24,13 @@ std = ["unsigned-varint/std", "alloc"]
 alloc = ["no_std_io2/alloc"]
 arb = ["dep:quickcheck", "dep:rand", "dep:arbitrary"]
 scale-codec = ["dep:parity-scale-codec"]
-serde-codec = ["serde"]                               # Deprecated, don't use.
+serde-codec = ["serde"] # Deprecated, don't use.
 serde = ["dep:serde"]
 
 [dependencies]
-parity-scale-codec = { version = "3.0.0", default-features = false, features = [
-  "derive",
-], optional = true }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
-rand = { version = "0.10", default-features = false, features = [
-  "alloc",
-], optional = true }
+rand = { version = "0.10", default-features = false, features = ["alloc"], optional = true }
 serde = { version = "1.0.116", optional = true, default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.116", optional = true, default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
 
-no_std_io2 = { version = "0.9", default-features = false }
+no_std_io2 = { version = "0.8.1", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -42,7 +42,7 @@ sha3 = { version = "0.11", default-features = false, optional = true }
 strobe-rs = { version = "0.13", default-features = false, optional = true }
 ripemd = { version = "0.2", default-features = false, optional = true }
 multihash-derive = { version = "0.9.1", path = "../derive", default-features = false }
-no_std_io2 = { version = "0.9", default-features = false }
+no_std_io2 = { version = "0.8.1", default-features = false }
 digest = { version = "0.11", default-features = false }
 serde = { version = "1.0.158", features = [
   "derive",

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -10,7 +10,18 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = ["blake2b_simd?/std", "blake2s_simd?/std", "blake3?/std", "digest/alloc", "sha1?/alloc", "sha2?/alloc", "sha3?/alloc", "ripemd?/alloc", "multihash-derive/std", "core2/std"]
+std = [
+  "blake2b_simd?/std",
+  "blake2s_simd?/std",
+  "blake3?/std",
+  "digest/alloc",
+  "sha1?/alloc",
+  "sha2?/alloc",
+  "sha3?/alloc",
+  "ripemd?/alloc",
+  "multihash-derive/std",
+  "no_std_io2/std",
+]
 arb = ["dep:arbitrary", "std"]
 sha1 = ["dep:sha1"]
 sha2 = ["dep:sha2"]
@@ -31,9 +42,11 @@ sha3 = { version = "0.11", default-features = false, optional = true }
 strobe-rs = { version = "0.13", default-features = false, optional = true }
 ripemd = { version = "0.2", default-features = false, optional = true }
 multihash-derive = { version = "0.9.1", path = "../derive", default-features = false }
-core2 = { version = "0.4.0", default-features = false }
+no_std_io2 = { version = "0.9", default-features = false }
 digest = { version = "0.11", default-features = false }
-serde = { version = "1.0.158", features = ["derive"], default-features = false, optional = true }
+serde = { version = "1.0.158", features = [
+  "derive",
+], default-features = false, optional = true }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
@@ -49,7 +62,16 @@ harness = false
 
 [[test]]
 name = "lib"
-required-features = ["sha1", "sha2", "sha3", "ripemd", "strobe", "blake2b", "blake2s", "blake3"]
+required-features = [
+  "sha1",
+  "sha2",
+  "sha3",
+  "ripemd",
+  "strobe",
+  "blake2b",
+  "blake2s",
+  "blake3",
+]
 
 [[example]]
 name = "custom_table"
@@ -62,5 +84,16 @@ path = "examples/manual_mh.rs"
 required-features = ["sha2"]
 
 [package.metadata.docs.rs]
-features = ["std", "sha1", "sha2", "sha3", "ripemd", "strobe", "blake2b", "blake2s", "blake3", "serde"]
+features = [
+  "std",
+  "sha1",
+  "sha2",
+  "sha3",
+  "ripemd",
+  "strobe",
+  "blake2b",
+  "blake2s",
+  "blake3",
+  "serde",
+]
 rustdoc-args = ["--cfg", "docs_rs"]

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -10,18 +10,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = [
-  "blake2b_simd?/std",
-  "blake2s_simd?/std",
-  "blake3?/std",
-  "digest/alloc",
-  "sha1?/alloc",
-  "sha2?/alloc",
-  "sha3?/alloc",
-  "ripemd?/alloc",
-  "multihash-derive/std",
-  "no_std_io2/std",
-]
+std = ["blake2b_simd?/std", "blake2s_simd?/std", "blake3?/std", "digest/alloc", "sha1?/alloc", "sha2?/alloc", "sha3?/alloc", "ripemd?/alloc", "multihash-derive/std", "no_std_io2/std"]
 arb = ["dep:arbitrary", "std"]
 sha1 = ["dep:sha1"]
 sha2 = ["dep:sha2"]
@@ -44,9 +33,7 @@ ripemd = { version = "0.2", default-features = false, optional = true }
 multihash-derive = { version = "0.9.1", path = "../derive", default-features = false }
 no_std_io2 = { version = "0.8.1", default-features = false }
 digest = { version = "0.11", default-features = false }
-serde = { version = "1.0.158", features = [
-  "derive",
-], default-features = false, optional = true }
+serde = { version = "1.0.158", features = ["derive"], default-features = false, optional = true }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 
 [dev-dependencies]
@@ -62,16 +49,7 @@ harness = false
 
 [[test]]
 name = "lib"
-required-features = [
-  "sha1",
-  "sha2",
-  "sha3",
-  "ripemd",
-  "strobe",
-  "blake2b",
-  "blake2s",
-  "blake3",
-]
+required-features = ["sha1", "sha2", "sha3", "ripemd", "strobe", "blake2b", "blake2s", "blake3"]
 
 [[example]]
 name = "custom_table"
@@ -84,16 +62,5 @@ path = "examples/manual_mh.rs"
 required-features = ["sha2"]
 
 [package.metadata.docs.rs]
-features = [
-  "std",
-  "sha1",
-  "sha2",
-  "sha3",
-  "ripemd",
-  "strobe",
-  "blake2b",
-  "blake2s",
-  "blake3",
-  "serde",
-]
+features = ["std", "sha1", "sha2", "sha3", "ripemd", "strobe", "blake2b", "blake2s", "blake3", "serde"]
 rustdoc-args = ["--cfg", "docs_rs"]

--- a/codetable/src/hasher_impl.rs
+++ b/codetable/src/hasher_impl.rs
@@ -6,15 +6,15 @@
 ))]
 macro_rules! derive_write {
     ($name:ident) => {
-        impl<const S: usize> core2::io::Write for $name<S> {
-            fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
+        impl<const S: usize> no_std_io2::io::Write for $name<S> {
+            fn write(&mut self, buf: &[u8]) -> no_std_io2::io::Result<usize> {
                 use multihash_derive::Hasher as _;
 
                 self.update(buf);
                 Ok(buf.len())
             }
 
-            fn flush(&mut self) -> core2::io::Result<()> {
+            fn flush(&mut self) -> no_std_io2::io::Result<()> {
                 Ok(())
             }
         }
@@ -194,15 +194,15 @@ macro_rules! derive_rustcrypto_hasher {
             }
         }
 
-        impl core2::io::Write for $name {
-            fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
+        impl no_std_io2::io::Write for $name {
+            fn write(&mut self, buf: &[u8]) -> no_std_io2::io::Result<usize> {
                 use multihash_derive::Hasher as _;
 
                 self.update(buf);
                 Ok(buf.len())
             }
 
-            fn flush(&mut self) -> core2::io::Result<()> {
+            fn flush(&mut self) -> no_std_io2::io::Result<()> {
                 Ok(())
             }
         }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -13,7 +13,7 @@ std = ["multihash/std", "no_std_io2/std"]
 [dependencies]
 multihash-derive-impl = { version = "0.1.2", path = "../derive-impl" }
 multihash = { version = "0.19.2", path = "../", default-features = false }
-no_std_io2 = { version = "0.9", default-features = false }
+no_std_io2 = { version = "0.8.1", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0.80"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/multiformats/rust-multihash"
 
 [features]
 default = ["std"]
-std = ["multihash/std", "core2/std"]
+std = ["multihash/std", "no_std_io2/std"]
 
 [dependencies]
 multihash-derive-impl = { version = "0.1.2", path = "../derive-impl" }
 multihash = { version = "0.19.2", path = "../", default-features = false }
-core2 = { version = "0.4.0", default-features = false }
+no_std_io2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0.80"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -78,7 +78,7 @@ impl fmt::Display for UnsupportedCode {
     }
 }
 
-impl core2::error::Error for UnsupportedCode {}
+impl no_std_io2::error::Error for UnsupportedCode {}
 
 /// Trait that implements hashing.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use core2::{error::Error as StdError, io};
+use no_std_io2::{error::Error as StdError, io};
 #[cfg(feature = "std")]
 use std::{error::Error as StdError, io};
 
@@ -90,7 +90,7 @@ impl StdError for Error {
         match &self.kind {
             Kind::Io(inner) => Some(inner),
             Kind::InvalidSize(_) => None,
-            Kind::Varint(_) => None, // FIXME: Does not implement `core2::Error`.
+            Kind::Varint(_) => None, // FIXME: Does not implement `no_std_io2::Error`.
         }
     }
 }

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -11,7 +11,7 @@ use unsigned_varint::encode as varint_encode;
 use std::io;
 
 #[cfg(not(feature = "std"))]
-use core2::io;
+use no_std_io2::io;
 
 /// A Multihash instance that only supports the basic functionality and no hashing.
 ///


### PR DESCRIPTION
`core2` was yanked a couple of hours ago. This MR removes the dependency in favor of `no_std_io2`.