### PR TITLE
chore: bump MSRV and remove `no_std_io2` from `multihash-derive`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,23 @@
 members = ["derive", "derive-impl", ".", "codetable"]
 resolver = "2"
 
+[workspace.package]
+repository = "https://github.com/multiformats/rust-multihash"
+license = "MIT"
+edition = "2021"
+rust-version = "1.81" # `core::error::Error` has been stabilized since `1.81`
+
 [package]
 name = "multihash"
 description = "Implementation of the multihash format"
-repository = "https://github.com/multiformats/rust-multihash"
 keywords = ["multihash", "ipfs"]
 version = "0.19.4"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "David Craven <david@craven.ch>", "Volker Mische <volker.mische@gmail.com>"]
-license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/multihash/"
-edition = "2021"
-rust-version = "1.64"
+repository = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -27,6 +32,9 @@ scale-codec = ["dep:parity-scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.
 serde = ["dep:serde"]
 
+[workspace.dependencies]
+no_std_io2 = { version = "0.9", default-features = false }
+
 [dependencies]
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
 quickcheck = { version = "1.0.3", optional = true }
@@ -35,7 +43,7 @@ serde = { version = "1.0.116", optional = true, default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
 
-no_std_io2 = { version = "0.8.1", default-features = false }
+no_std_io2 = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ resolver = "2"
 repository = "https://github.com/multiformats/rust-multihash"
 license = "MIT"
 edition = "2021"
-rust-version = "1.81" # `core::error::Error` has been stabilized since `1.81`
 
 [package]
 name = "multihash"
@@ -18,7 +17,7 @@ readme = "README.md"
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = { workspace = true }
+rust-version = "1.81" # `core::error::Error` has been stabilized since `1.81`
 
 [package.metadata.docs.rs]
 all-features = true

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.2.1"
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.81"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.2.1"
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -2,9 +2,10 @@
 name = "multihash-codetable"
 description = "Default multihash code-table with cryptographically secure hash implementations"
 version = "0.2.1"
-repository = "https://github.com/multiformats/rust-multihash"
-license = "MIT"
-edition = "2021"
+repository = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -31,7 +32,7 @@ sha3 = { version = "0.11", default-features = false, optional = true }
 strobe-rs = { version = "0.13", default-features = false, optional = true }
 ripemd = { version = "0.2", default-features = false, optional = true }
 multihash-derive = { version = "0.9.2", path = "../derive", default-features = false }
-no_std_io2 = { version = "0.8.1", default-features = false }
+no_std_io2 = { workspace = true }
 digest = { version = "0.11", default-features = false }
 serde = { version = "1.0.158", features = ["derive"], default-features = false, optional = true }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }

--- a/derive-impl/Cargo.toml
+++ b/derive-impl/Cargo.toml
@@ -6,6 +6,7 @@ description = "Internal proc-macro crate for the MultihashDigest derive"
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.81"
 
 [lib]
 proc-macro = true

--- a/derive-impl/Cargo.toml
+++ b/derive-impl/Cargo.toml
@@ -6,7 +6,6 @@ description = "Internal proc-macro crate for the MultihashDigest derive"
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/derive-impl/Cargo.toml
+++ b/derive-impl/Cargo.toml
@@ -2,10 +2,11 @@
 name = "multihash-derive-impl"
 version = "0.1.2"
 authors = ["David Craven <david@craven.ch>"]
-edition = "2018"
 description = "Internal proc-macro crate for the MultihashDigest derive"
-license = "MIT"
-repository = "https://github.com/multiformats/rust-multihash"
+repository = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "multihash-derive"
 version = "0.9.2"
-edition = "2018"
 description = "Proc macro for deriving custom multihash tables."
-license = "MIT"
-repository = "https://github.com/multiformats/rust-multihash"
+repository = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
 
 [features]
 default = ["std"]
-std = ["multihash/std", "no_std_io2/std"]
+std = ["multihash/std"]
 
 [dependencies]
 multihash-derive-impl = { version = "0.1.2", path = "../derive-impl" }
 multihash = { version = "0.19.2", path = "../", default-features = false }
-no_std_io2 = { version = "0.8.1", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0.80"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -5,7 +5,6 @@ description = "Proc macro for deriving custom multihash tables."
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-rust-version = { workspace = true }
 
 [features]
 default = ["std"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -5,6 +5,7 @@ description = "Proc macro for deriving custom multihash tables."
 repository = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = "1.81"
 
 [features]
 default = ["std"]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -78,7 +78,7 @@ impl fmt::Display for UnsupportedCode {
     }
 }
 
-impl no_std_io2::error::Error for UnsupportedCode {}
+impl core::error::Error for UnsupportedCode {}
 
 /// Trait that implements hashing.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use core::error::Error as StdError;
 #[cfg(not(feature = "std"))]
 use no_std_io2::io;
 #[cfg(feature = "std")]
@@ -86,8 +85,8 @@ impl core::fmt::Display for Kind {
     }
 }
 
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match &self.kind {
             Kind::Io(inner) => Some(inner),
             Kind::InvalidSize(_) => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
+use core::error::Error as StdError;
 #[cfg(not(feature = "std"))]
-use no_std_io2::{error::Error as StdError, io};
+use no_std_io2::io;
 #[cfg(feature = "std")]
-use std::{error::Error as StdError, io};
+use std::io;
 
 use unsigned_varint::decode;
 
@@ -56,7 +57,7 @@ pub(crate) fn unsigned_varint_to_multihash_error(err: unsigned_varint::io::ReadE
         unsigned_varint::io::ReadError::Decode(err) => Error {
             kind: Kind::Varint(err),
         },
-        other => io_to_multihash_error(io::Error::new(io::ErrorKind::Other, other)),
+        other => io_to_multihash_error(io::Error::other(other)),
     }
 }
 


### PR DESCRIPTION
- Bump MSVR to `1.81` as `core::error::Error` was stablized in `1.81`: https://releases.rs/docs/1.81.0/#stabilized-apis
- Remove `no_std_io2` from `multihash-derive`
- (Upcoming: make `no_std_io2` optional in a subsequent PR)