### PR TITLE
Embed minimal required `no_std_io2` traits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,22 @@ jobs:
       - name: Build
         run: cargo build --no-default-features --workspace --target thumbv6m-none-eabi
         shell: bash
+  
+  build-no-std-with-alloc:
+    name: Build no_std with `alloc` feature enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v6
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv6m-none-eabi
+
+      - name: Build
+        run: cargo build --no-default-features --features alloc --workspace --target thumbv6m-none-eabi
+        shell: bash
 
   build-no-std-with-serde:
     name: Build no_std with `serde` feature enabled

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ all-features = true
 [features]
 default = ["std"]
 std = ["unsigned-varint/std", "alloc"]
-alloc = ["no_std_io2/alloc"]
+alloc = []
 arb = ["dep:quickcheck", "dep:rand", "dep:arbitrary"]
 scale-codec = ["dep:parity-scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.
@@ -41,8 +41,6 @@ rand = { version = "0.10", default-features = false, features = ["alloc"], optio
 serde = { version = "1.0.116", optional = true, default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
-
-no_std_io2 = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/codetable/Cargo.toml
+++ b/codetable/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.81"
 
 [features]
 default = ["std"]
-std = ["blake2b_simd?/std", "blake2s_simd?/std", "blake3?/std", "digest/alloc", "sha1?/alloc", "sha2?/alloc", "sha3?/alloc", "ripemd?/alloc", "multihash-derive/std", "no_std_io2/std"]
+std = ["blake2b_simd?/std", "blake2s_simd?/std", "blake3?/std", "digest/alloc", "sha1?/alloc", "sha2?/alloc", "sha3?/alloc", "ripemd?/alloc", "multihash-derive/std"]
 arb = ["dep:arbitrary", "std"]
 sha1 = ["dep:sha1"]
 sha2 = ["dep:sha2"]
@@ -32,7 +32,6 @@ sha3 = { version = "0.11", default-features = false, optional = true }
 strobe-rs = { version = "0.13", default-features = false, optional = true }
 ripemd = { version = "0.2", default-features = false, optional = true }
 multihash-derive = { version = "0.9.2", path = "../derive", default-features = false }
-no_std_io2 = { workspace = true }
 digest = { version = "0.11", default-features = false }
 serde = { version = "1.0.158", features = ["derive"], default-features = false, optional = true }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }

--- a/codetable/src/hasher_impl.rs
+++ b/codetable/src/hasher_impl.rs
@@ -6,15 +6,16 @@
 ))]
 macro_rules! derive_write {
     ($name:ident) => {
-        impl<const S: usize> no_std_io2::io::Write for $name<S> {
-            fn write(&mut self, buf: &[u8]) -> no_std_io2::io::Result<usize> {
+        #[cfg(feature = "std")]
+        impl<const S: usize> std::io::Write for $name<S> {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
                 use multihash_derive::Hasher as _;
 
                 self.update(buf);
                 Ok(buf.len())
             }
 
-            fn flush(&mut self) -> no_std_io2::io::Result<()> {
+            fn flush(&mut self) -> std::io::Result<()> {
                 Ok(())
             }
         }
@@ -194,15 +195,16 @@ macro_rules! derive_rustcrypto_hasher {
             }
         }
 
-        impl no_std_io2::io::Write for $name {
-            fn write(&mut self, buf: &[u8]) -> no_std_io2::io::Result<usize> {
+        #[cfg(feature = "std")]
+        impl std::io::Write for $name {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
                 use multihash_derive::Hasher as _;
 
                 self.update(buf);
                 Ok(buf.len())
             }
 
-            fn flush(&mut self) -> no_std_io2::io::Result<()> {
+            fn flush(&mut self) -> std::io::Result<()> {
                 Ok(())
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use no_std_io2::io;
+use crate::no_std_io as io;
 #[cfg(feature = "std")]
 use std::io;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ extern crate alloc;
 mod arb;
 mod error;
 mod multihash;
+#[cfg(not(feature = "std"))]
+pub mod no_std_io; // Make it public for downstream crates(e.g. `cid`).
 #[cfg(feature = "serde")]
 mod serde;
 

--- a/src/multihash.rs
+++ b/src/multihash.rs
@@ -11,7 +11,7 @@ use unsigned_varint::encode as varint_encode;
 use std::io;
 
 #[cfg(not(feature = "std"))]
-use no_std_io2::io;
+use crate::no_std_io as io;
 
 /// A Multihash instance that only supports the basic functionality and no hashing.
 ///

--- a/src/no_std_io/error.rs
+++ b/src/no_std_io/error.rs
@@ -1,0 +1,100 @@
+use core::{fmt, result};
+
+pub(super) type Result<T> = result::Result<T, Error>;
+
+/// A minimal backfill of the [`std::io::Error`] for `no_std` environments.
+pub struct Error {
+    repr: Repr,
+}
+
+impl core::error::Error for Error {}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.repr, f)
+    }
+}
+
+enum Repr {
+    Custom(Custom),
+}
+
+#[derive(Debug)]
+struct Custom {
+    kind: ErrorKind,
+    error: &'static str,
+}
+
+/// A list specifying general categories of I/O error.
+///
+/// This list is intended to grow over time and it is not recommended to
+/// exhaustively match against it.
+///
+/// It is used with the [`io::Error`] type.
+///
+/// [`io::Error`]: Error
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(super) enum ErrorKind {
+    /// An error returned when an operation could not be completed because a
+    /// call to [`write`] returned [`Ok(0)`].
+    ///
+    /// This typically means that an operation could only succeed if it wrote a
+    /// particular number of bytes but only a smaller number of bytes could be
+    /// written.
+    ///
+    /// [`write`]: crate::io::Write::write
+    /// [`Ok(0)`]: Ok
+    WriteZero,
+    /// This operation was interrupted.
+    ///
+    /// Interrupted operations can typically be retried.
+    Interrupted,
+    /// An error returned when an operation could not be completed because an
+    /// "end of file" was reached prematurely.
+    ///
+    /// This typically means that an operation could only succeed if it read a
+    /// particular number of bytes but only a smaller number of bytes could be
+    /// read.
+    UnexpectedEof,
+}
+
+impl Error {
+    /// Creates a new I/O error from a known kind of error as well as an
+    /// arbitrary error payload.
+    ///
+    /// This function is used to generically create I/O errors which do not
+    /// originate from the OS itself. The `error` argument is an arbitrary
+    /// payload which will be contained in this [`Error`].
+    pub(super) fn new(kind: ErrorKind, error: &'static str) -> Error {
+        Self::_new(kind, error)
+    }
+
+    fn _new(kind: ErrorKind, error: &'static str) -> Error {
+        Error {
+            repr: Repr::Custom(Custom { kind, error }),
+        }
+    }
+
+    /// Returns the corresponding [`ErrorKind`] for this error.
+    pub(super) fn kind(&self) -> ErrorKind {
+        match self.repr {
+            Repr::Custom(ref c) => c.kind,
+        }
+    }
+}
+
+impl fmt::Debug for Repr {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Repr::Custom(ref c) => fmt::Debug::fmt(&c, fmt),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.repr {
+            Repr::Custom(ref c) => c.error.fmt(fmt),
+        }
+    }
+}

--- a/src/no_std_io/error.rs
+++ b/src/no_std_io/error.rs
@@ -3,27 +3,13 @@ use core::{fmt, result};
 pub(super) type Result<T> = result::Result<T, Error>;
 
 /// A minimal backfill of the [`std::io::Error`] for `no_std` environments.
-pub struct Error {
-    repr: Repr,
-}
-
-impl core::error::Error for Error {}
-
-impl fmt::Debug for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.repr, f)
-    }
-}
-
-enum Repr {
-    Custom(Custom),
-}
-
 #[derive(Debug)]
-struct Custom {
+pub struct Error {
     kind: ErrorKind,
     error: &'static str,
 }
+
+impl core::error::Error for Error {}
 
 /// A list specifying general categories of I/O error.
 ///
@@ -66,35 +52,17 @@ impl Error {
     /// originate from the OS itself. The `error` argument is an arbitrary
     /// payload which will be contained in this [`Error`].
     pub(super) fn new(kind: ErrorKind, error: &'static str) -> Error {
-        Self::_new(kind, error)
-    }
-
-    fn _new(kind: ErrorKind, error: &'static str) -> Error {
-        Error {
-            repr: Repr::Custom(Custom { kind, error }),
-        }
+        Error { kind, error }
     }
 
     /// Returns the corresponding [`ErrorKind`] for this error.
     pub(super) fn kind(&self) -> ErrorKind {
-        match self.repr {
-            Repr::Custom(ref c) => c.kind,
-        }
-    }
-}
-
-impl fmt::Debug for Repr {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Repr::Custom(ref c) => fmt::Debug::fmt(&c, fmt),
-        }
+        self.kind
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.repr {
-            Repr::Custom(ref c) => c.error.fmt(fmt),
-        }
+        self.error.fmt(fmt)
     }
 }

--- a/src/no_std_io/impls.rs
+++ b/src/no_std_io/impls.rs
@@ -1,5 +1,3 @@
-//! Ported from <https://docs.rs/crate/core2/0.4.0/source/src/io/impls.rs>
-
 use super::error::{Error, ErrorKind, Result};
 use super::traits::{Read, Write};
 
@@ -22,6 +20,10 @@ impl<W: Write + ?Sized> Write for &mut W {
     }
 }
 
+/// Read is implemented for `&[u8]` by copying from the slice.
+///
+/// Note that reading updates the slice to point to the yet unread part.
+/// The slice will be empty when EOF is reached.
 impl Read for &[u8] {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -65,6 +67,11 @@ impl Read for &[u8] {
     }
 }
 
+/// Write is implemented for `&mut [u8]` by copying into the slice, overwriting
+/// its data.
+///
+/// Note that writing updates the slice to point to the yet unwritten part.
+/// The slice will be empty when it has been completely overwritten.
 impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, data: &[u8]) -> Result<usize> {
@@ -88,6 +95,8 @@ impl Write for &mut [u8] {
     }
 }
 
+/// Write is implemented for `Vec<u8>` by appending to the vector.
+/// The vector will grow as needed.
 #[cfg(feature = "alloc")]
 impl Write for alloc::vec::Vec<u8> {
     #[inline]

--- a/src/no_std_io/impls.rs
+++ b/src/no_std_io/impls.rs
@@ -1,0 +1,104 @@
+//! Ported from <https://docs.rs/crate/core2/0.4.0/source/src/io/impls.rs>
+
+use super::error::{Error, ErrorKind, Result};
+use super::traits::{Read, Write};
+
+impl<R: Read + ?Sized> Read for &mut R {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        (**self).read(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        (**self).read_exact(buf)
+    }
+}
+
+impl<W: Write + ?Sized> Write for &mut W {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (**self).write(buf)
+    }
+}
+
+impl Read for &[u8] {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let amt = core::cmp::min(buf.len(), self.len());
+        let (a, b) = self.split_at(amt);
+
+        // First check if the amount of bytes we want to read is small:
+        // `copy_from_slice` will generally expand to a call to `memcpy`, and
+        // for a single byte the overhead is significant.
+        if amt == 1 {
+            buf[0] = a[0];
+        } else {
+            buf[..amt].copy_from_slice(a);
+        }
+
+        *self = b;
+        Ok(amt)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+        if buf.len() > self.len() {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ));
+        }
+        let (a, b) = self.split_at(buf.len());
+
+        // First check if the amount of bytes we want to read is small:
+        // `copy_from_slice` will generally expand to a call to `memcpy`, and
+        // for a single byte the overhead is significant.
+        if buf.len() == 1 {
+            buf[0] = a[0];
+        } else {
+            buf.copy_from_slice(a);
+        }
+
+        *self = b;
+        Ok(())
+    }
+}
+
+impl Write for &mut [u8] {
+    #[inline]
+    fn write(&mut self, data: &[u8]) -> Result<usize> {
+        let amt = core::cmp::min(data.len(), self.len());
+        let (a, b) = core::mem::take(self).split_at_mut(amt);
+        a.copy_from_slice(&data[..amt]);
+        *self = b;
+        Ok(amt)
+    }
+
+    #[inline]
+    fn write_all(&mut self, data: &[u8]) -> Result<()> {
+        if self.write(data)? == data.len() {
+            Ok(())
+        } else {
+            Err(Error::new(
+                ErrorKind::WriteZero,
+                "failed to write whole buffer",
+            ))
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Write for alloc::vec::Vec<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+}

--- a/src/no_std_io/mod.rs
+++ b/src/no_std_io/mod.rs
@@ -1,0 +1,11 @@
+//! No-std I/O utilities for the multihash crate.
+//!
+//! This module provides a minimal compatibility layer for I/O operations in `no_std` environments.
+//! Source code is ported and adapted from the [`core2`](https://docs.rs/crate/core2/0.4.0/source/) crate.
+
+mod error;
+mod impls;
+mod traits;
+
+pub use error::Error;
+pub use traits::{Read, Write};

--- a/src/no_std_io/traits.rs
+++ b/src/no_std_io/traits.rs
@@ -1,0 +1,54 @@
+use super::error::{Error, ErrorKind, Result};
+
+/// A minimal backfill of the [`std::io::Read`] for `no_std` environments.
+pub trait Read {
+    /// Backfill of the [`std::io::Read::read`].
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+
+    /// Backfill of the [`std::io::Read::read_exact`].
+    fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.read(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        if !buf.is_empty() {
+            Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// A minimal backfill of the [`std::io::Write`] for `no_std` environments.
+pub trait Write {
+    /// Backfill of the [`std::io::Write::write`].
+    fn write(&mut self, buf: &[u8]) -> Result<usize>;
+
+    /// Backfill of the [`std::io::Write::write_all`].
+    fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => {
+                    return Err(Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR embedded minimal `no_std_io2` traits that are required by `multihash`. It should require a minor version bump