### PR TITLE
chore: prepare v0.19.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.19.5](https://github.com/multiformats/rust-multihash/compare/v0.19.4...v0.19.5) (2026-04-27)
+
+### Features
+
+* embed minimal required core2/no_std_io2 traits ([#411](https://github.com/multiformats/rust-multihash/issues/411)) ([90fab31](https://github.com/multiformats/rust-multihash/commit/90fab31ce86b5e87d281c6d718e053376852bf07))
+* Minimum supported Rust version (MSRV) is now 1.81, due to using `core::error::Error`.
+
+
 ## [0.19.4](https://github.com/multiformats/rust-multihash/compare/v0.19.3...v0.19.4) (2026-04-15)
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 name = "multihash"
 description = "Implementation of the multihash format"
 keywords = ["multihash", "ipfs"]
-version = "0.19.4"
+version = "0.19.5"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "David Craven <david@craven.ch>", "Volker Mische <volker.mische@gmail.com>"]
 readme = "README.md"
 repository = { workspace = true }


### PR DESCRIPTION
The plan would be to release a v0.19.5 version of the main `multihash` crate as it shouldn't really be a breaking change, it just changes internal implementations.

There is a large MSRV bump, but even Rust 1.81 is already over 1.5 years old. If someone really needs to support older versions, they can fix multihash to v0.19.4. If it turn out to be an issue for anyone, please open an issue.

@hanabi1224 As you can see my idea would be to release this as a patch release for `multihash`. Also patch releases for `multihash-derive` and `multihash-derive-impl` But release a minor for `multihash-codetable`, due to not implementing that custom `Write` for no-std. Does that sounds correct to you, or do you propose something else (you feedback would really be appreciated)?